### PR TITLE
docs: add docs/ and examples/

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,121 @@
+# Advanced recipes
+
+Once the basic `phonemize_sentence` loop is clear, these are the knobs worth
+knowing.
+
+## POS engines and homographs
+
+Portuguese homographs change pronunciation by part of speech. `tugaphone` tags
+the sentence first and feeds the tags into transcription, so the engine you pick
+affects accuracy:
+
+```python
+from tugaphone import TugaPhonemizer
+
+ph = TugaPhonemizer(postag_engine="spacy")    # most accurate, needs pt_core_news_lg
+ph.phonemize_sentence("Vou para casa.")        # 'para' as preposition
+ph.phonemize_sentence("Ele para o carro.")     # 'para' as verb
+```
+
+Engine options, from heaviest to lightest:
+
+| Engine | Needs | Notes |
+|--------|-------|-------|
+| `spacy` | `spacy` + `pt_core_news_lg` | Most accurate. |
+| `brill` | `brill-postaggers` | Lighter, faster; installed via `tugatagger[brill]`. |
+| `lexicon` | nothing extra | Built-in lookup, limited coverage. |
+| `dummy` | nothing | Rule-based fallback, no dependencies. |
+| `auto` | — | Falls through whatever is installed. Default. |
+
+If you only need deterministic output with no optional dependencies, construct
+with `postag_engine="dummy"`.
+
+## Regional accents
+
+On top of the five dialect codes, `tugaphone.regional` ships sub-regional accent
+presets as `RegionalTransforms`. Pass one through `regional_dialect`; it is
+applied on top of the `lang` dialect:
+
+```python
+from tugaphone import TugaPhonemizer
+from tugaphone.regional import (PortoDialect, MinhoDialect, BragaDialect,
+                                TrasMontanoDialect, FafeDialect)
+
+ph = TugaPhonemizer()
+sentence = "a gente sente o que sabe"
+for name, accent in [("porto", PortoDialect), ("minho", MinhoDialect),
+                     ("braga", BragaDialect), ("trasmontano", TrasMontanoDialect),
+                     ("fafe", FafeDialect)]:
+    print(name, "→", ph.phonemize_sentence(sentence, "pt-PT", regional_dialect=accent))
+```
+
+| Preset | Signature features |
+|--------|--------------------|
+| `CoimbraDialect` | Diphthong retention only (neutral baseline). |
+| `MinhoDialect` | Vowel-centralization resistance, open vowels, alveolar rhotic. |
+| `BragaDialect` | Palatal epenthesis (`abelha` → `abeilha`) on top of northern rules. |
+| `FamalicaoDialect` | Conservative `o`-nasal retention (`Famalicão` → `Famalicoum`). |
+| `TrasMontanoDialect` | `ch` affrication, s-voicing, final nasal denasalization. |
+| `PortoDialect` | Rising `o` diphthong (`Porto` → `Puorto`). |
+| `FafeDialect` | Nasal diphthongization of `e` (`gente` → `geinte`). |
+
+These are explicitly experimental — real variation is messier than any rule set.
+
+### Serializing an accent
+
+`RegionalTransforms` round-trips through a plain dict, so an accent config can
+live in JSON or YAML:
+
+```python
+from tugaphone.regional import PortoDialect, RegionalTransforms
+
+cfg = PortoDialect.as_dict
+# {'morpheme_rules': [], 'ipa_rules': ['rising_diphthong_o', ...]}
+
+clone = RegionalTransforms.from_dict(cfg)
+[r.__name__ for r in clone.ipa_rules]
+```
+
+`from_dict` raises `ValueError` on an unknown IPA rule name. Only rules listed in
+`tugaphone.regional.RULE_MAP` survive the round-trip; accents that use other rule
+functions serialize a subset of their behaviour.
+
+## Number normalization
+
+`normalize_numbers` spells digits out before transcription and is independently
+useful for any TTS front-end:
+
+```python
+from tugaphone.number_utils import normalize_numbers
+
+normalize_numbers("vou comprar 1 casa")      # 'vou comprar uma casa'  (feminine)
+normalize_numbers("vou adotar 1 cão")        # 'vou adotar um cão'      (masculine)
+normalize_numbers("897654356789098", "pt-PT")  # long scale (biliões)
+normalize_numbers("897654356789098", "pt-BR")  # short scale (trilhões)
+```
+
+Gender is inferred from preceding articles (`a`, `as`, `da`, `das`) and from the
+shape of the following noun (`-a`, `-dade`, `-agem` endings lean feminine). Pass
+`strict=False` to leave unparseable tokens in place instead of raising.
+
+## Integration with sibling libraries
+
+`tugaphone` composes three TigreGotico Portuguese NLP libraries; each is usable
+on its own:
+
+- [`tugalex`](https://github.com/TigreGotico/tugalex) — the phonetic lexicon
+  (`LEXICON` in `tugaphone.dialects`). `LEXICON.get_ipa_map(region=...)` returns
+  the per-region exception table.
+- [`tugatagger`](https://github.com/TigreGotico/tugatagger) — the POS tagger
+  behind `postag_engine`.
+- [`silabificador`](https://github.com/TigreGotico/silabificador) — the
+  syllabifier behind `WordToken.syllables`.
+
+A TTS front-end typically wires `tugaphone` as the G2P stage: normalize text,
+phonemize per target dialect, hand the IPA string to the acoustic model.
+
+## Where next
+
+- [api.md](api.md) — full signatures
+- [tokenizer.md](tokenizer.md) — inspect syllables, stress and graphemes directly
+- [quickstart.md](quickstart.md) — the basics

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,164 @@
+# API Reference
+
+Every public symbol, with the signatures and return shapes as they exist in the
+source.
+
+## `tugaphone.TugaPhonemizer`
+
+The phonemizer entry class.
+
+```python
+TugaPhonemizer(postag_engine="auto", postag_model="pt_core_news_lg")
+```
+
+| Argument | Meaning |
+|----------|---------|
+| `postag_engine` | POS tagging backend passed to `TugaTagger`: `"auto"`, `"spacy"`, `"brill"`, `"lexicon"`, `"dummy"`. |
+| `postag_model` | Model identifier for engines that take one (e.g. the spaCy model name). |
+
+Construction builds the `TugaTagger` and warms the lexicon so the first
+transcription is fast.
+
+### `phonemize_sentence`
+
+```python
+phonemize_sentence(sentence: str,
+                   lang: str = "pt-PT",
+                   regional_dialect: Optional[RegionalTransforms] = None) -> str
+```
+
+Transcribes `sentence` to IPA for the target dialect. Returns a space-separated
+phoneme string — one token per word, with `ˈ` for primary stress and `·` for
+syllable boundaries; punctuation tokens are preserved.
+
+`lang` is one of `pt-PT`, `pt-BR`, `pt-AO`, `pt-MZ`, `pt-TL`; any other value
+falls back to European Portuguese.
+
+When `regional_dialect` is given, the word is first run through the preset's
+morpheme rules, transcribed, then run through its IPA rules. See
+[`RegionalTransforms`](#tugaphoneregionalregionaltransforms).
+
+```python
+ph = TugaPhonemizer()
+ph.phonemize_sentence("O gato dorme.", "pt-BR")   # 'ˈu gˈa·tʊ ˈdɔh·me'
+```
+
+### `get_dialect_inventory` (staticmethod)
+
+```python
+TugaPhonemizer.get_dialect_inventory(lang: str = "pt-PT") -> DialectInventory
+```
+
+Maps a dialect code to its `DialectInventory` instance (`EuropeanPortuguese`,
+`BrazilianPortuguese`, `AngolanPortuguese`, `MozambicanPortuguese`,
+`TimoresePortuguese`).
+
+## `tugaphone.number_utils`
+
+### `normalize_numbers`
+
+```python
+normalize_numbers(text: str, lang: str = "pt-PT", strict: bool = True) -> str
+```
+
+Replaces numeric tokens in a sentence with their Portuguese written form,
+inferring gender and ordinality from the surrounding words. `pt-PT` uses the
+long scale (biliões), `pt-BR` the short scale (trilhões). With `strict=False`,
+tokens that fail to format are left untouched instead of raising.
+
+```python
+from tugaphone.number_utils import normalize_numbers
+normalize_numbers("vou comprar 1 casa")    # 'vou comprar uma casa'
+normalize_numbers("vou adotar 2 cães")     # 'vou adotar dois cães'
+normalize_numbers("1.5e10")                # 'um vírgula cinco vezes dez elevado a dez'
+```
+
+### `NumberParser`
+
+A classmethod-based helper underneath `normalize_numbers`. Useful when you need
+finer control or want to interrogate a single token.
+
+| Method | Returns |
+|--------|---------|
+| `pronounce_number_word(word, prev_word=None, next_word=None, gender=None, as_ordinal=None, is_brazilian=False)` | Spelled-out form of one numeric token. |
+| `to_int(word)` / `is_int(word)` | Integer value (ordinal markers stripped) / membership test. |
+| `to_float(word)` / `is_float(word)` | Float value / membership test. |
+| `is_scientific_notation(word)` | `True` for forms like `"1.5e10"`. |
+| `pronounce_scientific(word, is_brazilian=False)` | Spoken form of scientific notation. |
+| `is_ordinal(word, next_word=None)` | Detects `º`/`ª` markers, attached or separate. |
+| `get_number_gender(word, prev_word=None, next_word=None)` | `"feminine"` or `"masculine"`. |
+
+```python
+from tugaphone.number_utils import NumberParser
+NumberParser.pronounce_number_word("19", is_brazilian=True)   # 'dezenove'
+NumberParser.pronounce_number_word("19", is_brazilian=False)  # 'dezanove'
+NumberParser.pronounce_number_word("1", next_word="º")        # 'primeiro' (ordinal)
+NumberParser.get_number_gender("1", next_word="casa")         # 'feminine'
+```
+
+## `tugaphone.regional.RegionalTransforms`
+
+A serializable dataclass holding the rules for a sub-regional accent.
+
+```python
+@dataclass
+class RegionalTransforms:
+    morpheme_rules: List[MorphemeTransform] = []   # applied to the word before G2P
+    ipa_rules:      List[IPATransform]      = []    # applied to the IPA after G2P
+```
+
+| Member | Behaviour |
+|--------|-----------|
+| `apply_morpheme(word, postag="NOUN")` | Runs every morpheme rule in order, returns the rewritten word. |
+| `apply_ipa(word, phonemes, postag="NOUN")` | Runs every IPA rule in order, returns the rewritten phoneme string. |
+| `as_dict` (property) | Serializes the rule lists to rule-name strings. |
+| `from_dict(data)` (staticmethod) | Rebuilds an instance from `{"ipa_rules": [...], "morpheme_rules": [...]}`; raises `ValueError` on an unknown IPA rule name. |
+
+```python
+from tugaphone.regional import PortoDialect, RegionalTransforms
+
+cfg = PortoDialect.as_dict
+clone = RegionalTransforms.from_dict(cfg)
+[r.__name__ for r in clone.ipa_rules]   # ['rising_diphthong_o', ...]
+```
+
+### Preset accents
+
+Importable from `tugaphone.regional`: `CoimbraDialect`, `MinhoDialect`,
+`BragaDialect`, `FamalicaoDialect`, `TrasMontanoDialect`, `PortoDialect`,
+`FafeDialect`. Each is a ready-built `RegionalTransforms`. Pass any of them to
+`phonemize_sentence(..., regional_dialect=...)`.
+
+Only the IPA rules listed in `RULE_MAP` round-trip through `as_dict`/`from_dict`;
+accents built from other rule functions serialize a subset.
+
+## `tugaphone.dialects`
+
+| Symbol | Role |
+|--------|------|
+| `DialectInventory` | Base class: phoneme maps, character sets, stress/punctuation tokens. `dialect_code` attribute carries the tag. |
+| `EuropeanPortuguese`, `BrazilianPortuguese`, `AngolanPortuguese`, `MozambicanPortuguese`, `TimoresePortuguese` | The five dialect inventories. |
+| `LisbonPortuguese`, `RioJaneiroPortuguese`, `SaoPauloPortuguese` | City-specific inventories layered on the base dialects. |
+| `LEXICON` | Module-level `TugaLexicon()` instance; `LEXICON.get_ipa_map(region=...)` returns the per-region exception map. |
+
+You rarely instantiate these directly — `TugaPhonemizer` does it for you — but
+they are the `dialect` argument the tokenizer accepts.
+
+## `tugaphone.tokenizer`
+
+The hierarchical model. See [tokenizer.md](tokenizer.md) for the full walkthrough;
+the public surface is:
+
+| Symbol | Role |
+|--------|------|
+| `Sentence(surface, words=[], dialect=EuropeanPortuguese())` | Top-level container; `.ipa`, `.words`, `.n_words`, `.features`. |
+| `Sentence.from_postagged(surface, tags, dialect=None)` | Build from `(token, pos)` pairs (the path `TugaPhonemizer` uses). |
+| `WordToken` | `.surface`, `.syllables`, `.graphemes`, `.stressed_syllable_idx`, `.ipa`, `.features`. |
+| `GraphemeToken` | `.surface`, `.ipa`, `.is_diphthong`, `.is_nasal`, `.is_digraph`, `.features`, and more predicates. |
+| `CharToken` | character-level predicates (`.is_vowel`, `.is_consonant`, `.ipa`, ...). |
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first call
+- [advanced.md](advanced.md) — recipes for accents, POS engines, numbers
+- [tokenizer.md](tokenizer.md) — the token tree and feature extraction

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,105 @@
+# Quickstart — zero to hero
+
+`tugaphone` turns Portuguese text into IPA phonemes, and it does it per dialect.
+Give it a sentence and a Lusophone dialect code, get back a phoneme string with
+stress markers and syllable boundaries.
+
+```
+Choveu muito ontem à noite.
+pt-PT → ˈʃɔ·vew mˈũj·tu õ·ˈtẽ ˈa nˈoj·tɨ
+pt-BR → ˈʃɔ·vew mwˈĩ·tʊ õ·ˈtẽ ˈa nˈoj·tʃɪ
+```
+
+## 1. Install
+
+```bash
+pip install tugaphone            # from PyPI
+pip install -e .                 # from a source checkout
+```
+
+Runtime dependencies (`unicode-rbnf`, `silabificador`, `tugatagger[brill]`,
+`tugalex`) install automatically. The phonetic lexicon ships through
+[`tugalex`](https://github.com/TigreGotico/tugalex), which wraps the HuggingFace
+dataset `TigreGotico/portuguese_phonetic_lexicon`. It is lazy-loaded on first use
+and warmed during `TugaPhonemizer()` construction.
+
+## 2. The one thing to understand
+
+`TugaPhonemizer` is the entry point. You construct it once (it loads the lexicon
+and the POS tagger), then call `phonemize_sentence(text, lang)` as many times as
+you like. The `lang` argument is an IETF dialect tag and it changes the phonology,
+not just the spelling:
+
+```python
+from tugaphone import TugaPhonemizer
+
+ph = TugaPhonemizer()
+print(ph.phonemize_sentence("O gato dorme.", "pt-PT"))   # ˈu gˈa·tu ˈdɔʁ·mɨ
+print(ph.phonemize_sentence("O gato dorme.", "pt-BR"))   # ˈu gˈa·tʊ ˈdɔh·me
+```
+
+The return value is a space-separated phoneme string: one token per word, with
+`ˈ` marking primary stress and `·` marking syllable boundaries.
+
+## 3. Pick a dialect
+
+Five Lusophone dialects are supported through the `lang` argument:
+
+```python
+ph = TugaPhonemizer()
+for code in ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
+    print(code, "→", ph.phonemize_sentence("A menina comeu o pão todo.", code))
+```
+
+| Code | Region |
+|------|--------|
+| `pt-PT` | European Portuguese (Lisbon) |
+| `pt-BR` | Brazilian Portuguese (Rio) |
+| `pt-AO` | Angolan Portuguese (Luanda) |
+| `pt-MZ` | Mozambican Portuguese (Maputo) |
+| `pt-TL` | Timorese Portuguese (Dili) |
+
+Anything that is not one of the four non-European codes falls back to European
+Portuguese.
+
+## 4. First real call
+
+```python
+from tugaphone import TugaPhonemizer
+
+ph = TugaPhonemizer()
+sentence = "Vou pôr a manteiga no frigorífico."
+print(ph.phonemize_sentence(sentence, "pt-PT"))
+```
+
+Digits in your text are best spelled out first, with gender agreement, using the
+`normalize_numbers` helper:
+
+```python
+from tugaphone.number_utils import normalize_numbers
+
+text = normalize_numbers("comprei 2 casas")   # 'comprei duas casas'
+print(ph.phonemize_sentence(text, "pt-PT"))
+```
+
+## 5. Sub-regional accents
+
+On top of the five dialects, `tugaphone` ships experimental sub-regional accents
+as `RegionalTransforms` presets. Pass one through `regional_dialect`:
+
+```python
+from tugaphone import TugaPhonemizer
+from tugaphone.regional import PortoDialect
+
+ph = TugaPhonemizer()
+print(ph.phonemize_sentence("O Porto é uma cidade bonita.", regional_dialect=PortoDialect))
+```
+
+These are based on documented phonological features and should be treated as
+approximate. See [advanced.md](advanced.md#regional-accents) for the full list.
+
+## Where next
+
+- [api.md](api.md) — every public class, function and keyword argument with real signatures
+- [advanced.md](advanced.md) — regional accents, POS engines, number normalization, the token tree
+- [tokenizer.md](tokenizer.md) — the `Sentence → Word → Grapheme → Character` model and its features

--- a/docs/tokenizer.md
+++ b/docs/tokenizer.md
@@ -1,0 +1,101 @@
+# The token tree
+
+`phonemize_sentence` returns a string, but the transcription is built from a
+four-level model you can inspect directly:
+
+```
+Sentence → Word → Grapheme → Character
+```
+
+Each level carries phonological features and its own IPA. This is the layer to
+reach for when you want syllables, stress positions, diphthong detection, or a
+feature dict for machine learning — not just the final phoneme string.
+
+## Building a Sentence
+
+The simplest path constructs a `Sentence` with a dialect inventory:
+
+```python
+from tugaphone.tokenizer import Sentence
+from tugaphone.dialects import EuropeanPortuguese
+
+s = Sentence("O cão comeu o pão.", dialect=EuropeanPortuguese())
+print(s.ipa)        # 'ˈu kˈɐ̃w ˈkɔ·mew ˈu pˈɐ̃w'
+print(s.n_words)    # 4
+print(repr(s))      # Sentence('O cão comeu o pão.' → [...])
+```
+
+`TugaPhonemizer` itself uses `Sentence.from_postagged(surface, tags, dialect)`,
+where `tags` is a list of `(token, pos)` pairs. Use that form when you already
+have POS tags and want them respected during transcription.
+
+## Word level
+
+Each `WordToken` exposes its syllable structure, stress and per-word IPA:
+
+```python
+for word in s.words:
+    print(word.surface,
+          ".".join(word.syllables),
+          "stress@", word.stressed_syllable_idx,
+          "→", word.ipa)
+```
+
+```
+o    o        stress@ 0 → ˈu
+cão  cão      stress@ 0 → kˈɐ̃w
+comeu co.meu  stress@ 0 → ˈkɔ·mew
+```
+
+`syllables` comes from the `silabificador` library; `stressed_syllable_idx` is
+the index of the stressed syllable; `n_syllables` counts them.
+
+## Grapheme level
+
+A `GraphemeToken` groups characters into orthographic units (digraphs like `ch`
+and `nh`, diphthongs like `ão` and `ei`) and knows how each maps to IPA:
+
+```python
+word = s.words[1]   # cão
+for g in word.graphemes:
+    print(repr(g.surface), "→", g.ipa,
+          "diphthong" if g.is_diphthong else "",
+          "nasal" if g.is_nasal else "")
+```
+
+```
+'c'  → k
+'ão' → ɐ̃w  diphthong nasal
+```
+
+Useful grapheme predicates: `is_diphthong`, `is_triphthong`,
+`is_falling_diphthong`, `is_rising_diphthong`, `is_nasal_diphthong`,
+`is_oral_diphthong`, `is_nasal`, `is_digraph`, `is_trigraph`,
+`has_primary_stress`.
+
+## Character level
+
+The deepest level, `CharToken`, carries the phonetic primitives: `is_vowel`,
+`is_consonant`, `is_semivowel`, `is_nasal_vowel`, `is_open_vowel`,
+`is_intervocalic`, and its own `.ipa`. These drive the allophone rules the higher
+levels assemble.
+
+## Feature extraction
+
+Every level has a `.features` dict. `Sentence.features` flattens the whole tree
+into a single namespaced dict suitable for a feature vector:
+
+```python
+feats = s.features
+# {'n_words': 4, 'n_whitespaces': 3,
+#  'word_0_n_syllables': 1, 'word_0_stressed_syllable_idx': 0, 'word_0_pos': ...}
+```
+
+Long sentences produce large dictionaries — for ML pipelines, project the keys
+you need rather than materializing the whole thing per sample.
+
+## Where next
+
+- [api.md](api.md) — the class table and signatures
+- [advanced.md](advanced.md) — accents, POS engines, numbers
+- [quickstart.md](quickstart.md) — the basics

--- a/examples/01_basic.py
+++ b/examples/01_basic.py
@@ -1,0 +1,26 @@
+"""Example — phonemize a Portuguese sentence to IPA.
+
+Run::
+
+    python examples/01_basic.py
+"""
+from tugaphone import TugaPhonemizer
+
+
+def main() -> None:
+    ph = TugaPhonemizer()
+
+    sentences = [
+        "O gato dorme.",
+        "Tu falas português muito bem.",
+        "A menina comeu o pão todo.",
+        "Vou pôr a manteiga no frigorífico.",
+    ]
+
+    for s in sentences:
+        print(f"{s}")
+        print(f"  pt-PT → {ph.phonemize_sentence(s, 'pt-PT')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_dialects.py
+++ b/examples/02_dialects.py
@@ -1,0 +1,20 @@
+"""Example — the same sentence across the five Lusophone dialects.
+
+Run::
+
+    python examples/02_dialects.py
+"""
+from tugaphone import TugaPhonemizer
+
+
+def main() -> None:
+    ph = TugaPhonemizer()
+
+    sentence = "O comboio chegou à estação."
+    print(sentence)
+    for code in ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
+        print(f"  {code} → {ph.phonemize_sentence(sentence, code)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_regional_accents.py
+++ b/examples/03_regional_accents.py
@@ -1,0 +1,32 @@
+"""Example — experimental sub-regional accents on top of pt-PT.
+
+Run::
+
+    python examples/03_regional_accents.py
+"""
+from tugaphone import TugaPhonemizer
+from tugaphone.regional import (PortoDialect, MinhoDialect, BragaDialect,
+                                TrasMontanoDialect, FafeDialect)
+
+
+def main() -> None:
+    ph = TugaPhonemizer()
+
+    sentence = "a gente sente o que sabe"
+    accents = {
+        "pt-PT (base)": None,
+        "porto": PortoDialect,
+        "minho": MinhoDialect,
+        "braga": BragaDialect,
+        "trasmontano": TrasMontanoDialect,
+        "fafe": FafeDialect,
+    }
+
+    print(sentence)
+    for name, accent in accents.items():
+        ipa = ph.phonemize_sentence(sentence, "pt-PT", regional_dialect=accent)
+        print(f"  {name:14s} → {ipa}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_numbers.py
+++ b/examples/04_numbers.py
@@ -1,0 +1,36 @@
+"""Example — spell out numbers in Portuguese with gender and scale agreement.
+
+Run::
+
+    python examples/04_numbers.py
+"""
+from tugaphone.number_utils import normalize_numbers, NumberParser
+
+
+def main() -> None:
+    print("Gender agreement:")
+    for text in ["vou comprar 1 casa", "vou comprar 2 casas",
+                 "vou adotar 1 cão", "vou adotar 2 cães", "visitei 1 cidade"]:
+        print(f"  {text:22s} → {normalize_numbers(text)}")
+
+    print("\nOrdinals (via NumberParser, with the gender marker):")
+    print(f"  1 + º → {NumberParser.pronounce_number_word('1', next_word='º')}")
+    print(f"  1 + ª → {NumberParser.pronounce_number_word('1', next_word='ª')}")
+    print(f"  3 + º → {NumberParser.pronounce_number_word('3', next_word='º')}")
+
+    print("\nScientific notation:")
+    for text in ["1e9", "1.5e10"]:
+        print(f"  {text:22s} → {normalize_numbers(text)}")
+
+    print("\nScale differs by dialect:")
+    big = "897654356789098"
+    print(f"  pt-PT (long scale)  → {normalize_numbers(big, 'pt-PT')}")
+    print(f"  pt-BR (short scale) → {normalize_numbers(big, 'pt-BR')}")
+
+    print("\nSingle-token control via NumberParser:")
+    print(f"  19 (pt-BR) → {NumberParser.pronounce_number_word('19', is_brazilian=True)}")
+    print(f"  19 (pt-PT) → {NumberParser.pronounce_number_word('19', is_brazilian=False)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_token_tree.py
+++ b/examples/05_token_tree.py
@@ -1,0 +1,37 @@
+"""Example — inspect the Sentence -> Word -> Grapheme token tree.
+
+Run::
+
+    python examples/05_token_tree.py
+"""
+from tugaphone.tokenizer import Sentence
+from tugaphone.dialects import EuropeanPortuguese
+
+
+def main() -> None:
+    sentence = Sentence("O cão comeu o pão.", dialect=EuropeanPortuguese())
+
+    print(f"Sentence: {sentence.surface}")
+    print(f"IPA:      {sentence.ipa}")
+    print(f"Words:    {sentence.n_words}")
+    print()
+
+    for word in sentence.words:
+        print(f"  {word.surface}")
+        print(f"    syllables: {'.'.join(word.syllables)}")
+        print(f"    stress:    syllable {word.stressed_syllable_idx}")
+        print(f"    ipa:       {word.ipa}")
+        for g in word.graphemes:
+            tags = []
+            if g.is_diphthong:
+                tags.append("diphthong")
+            if g.is_nasal:
+                tags.append("nasal")
+            if g.is_digraph:
+                tags.append("digraph")
+            label = f" [{', '.join(tags)}]" if tags else ""
+            print(f"      grapheme {g.surface!r} → {g.ipa}{label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_serialize_accent.py
+++ b/examples/06_serialize_accent.py
@@ -1,0 +1,31 @@
+"""Example — serialize a regional accent to a dict and rebuild it.
+
+Run::
+
+    python examples/06_serialize_accent.py
+"""
+from tugaphone.regional import PortoDialect, RegionalTransforms
+
+
+def main() -> None:
+    cfg = PortoDialect.as_dict
+    print("Serialized PortoDialect:")
+    print(f"  ipa_rules:      {cfg['ipa_rules']}")
+    print(f"  morpheme_rules: {cfg['morpheme_rules']}")
+
+    clone = RegionalTransforms.from_dict(cfg)
+    print(f"\nRebuilt accent has {len(clone.ipa_rules)} IPA rules.")
+    print(f"First rule: {clone.ipa_rules[0].__name__}")
+
+    print("\nApplying the rebuilt rules to a phoneme string:")
+    sample = "pˈoɾ·tu"
+    print(f"  {sample} → {clone.apply_ipa(word='porto', phonemes=sample)}")
+
+    try:
+        RegionalTransforms.from_dict({"ipa_rules": ["does_not_exist"]})
+    except ValueError as e:
+        print(f"\nUnknown rule names raise: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a documentation set and runnable example scripts for tugaphone.

## docs/
- `quickstart.md` — install, the core `TugaPhonemizer` idea, dialect selection, first calls, and standalone number normalization.
- `api.md` — every public class, function and keyword argument: `TugaPhonemizer`, `normalize_numbers`, `NumberParser`, `RegionalTransforms` and its presets, the dialect inventories, and the tokenizer surface.
- `advanced.md` — POS engines and homographs, the regional accent presets, accent serialization, number normalization, and integration with tugalex/tugatagger/silabificador.
- `tokenizer.md` — the Sentence -> Word -> Grapheme -> Character model and feature extraction.

## examples/
- `01_basic.py` — phonemize Portuguese sentences to IPA.
- `02_dialects.py` — one sentence across pt-PT, pt-BR, pt-AO, pt-MZ, pt-TL.
- `03_regional_accents.py` — sub-regional accents over pt-PT.
- `04_numbers.py` — gender agreement, ordinals, scientific notation, long/short scale.
- `05_token_tree.py` — inspect syllables, stress and graphemes.
- `06_serialize_accent.py` — serialize and rebuild a RegionalTransforms accent.

All six examples run clean against the public API and stdlib only.