### PR TITLE
feat: source stress rules from orthography2ipa and ship its pt syllabifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ keywords = ["portuguese", "phonemizer", "g2p", "ipa", "phonetics", "tts", "nlp"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: Portuguese",
     "Natural Language :: Portuguese (Brazilian)",
     "Programming Language :: Python :: 3",
@@ -32,7 +31,11 @@ dependencies = [
     "silabificador",
     "tugatagger[brill]",
     "tugalex",
+    "orthography2ipa>=0.3.0a1",
 ]
+
+[project.entry-points."orthography2ipa.syllabify"]
+portuguese = "tugaphone.plugin:SilabificadorSyllabifier"
 
 [project.optional-dependencies]
 test = [

--- a/tests/test_orthography2ipa_base.py
+++ b/tests/test_orthography2ipa_base.py
@@ -1,0 +1,104 @@
+"""Tests for the orthography2ipa integration.
+
+Validates:
+- stress detection delegates to the pt spec's declarative StressRules
+  (correcting the overbroad bare -m/-n oxytone triggers)
+- SilabificadorSyllabifier registers in the orthography2ipa.syllabify
+  group and feeds orthography2ipa's own stress detection
+- TugaphoneG2PPlugin implements the shared engine interface lazily
+- differential audit: hand-tuned CHAR2IPA values appear among the
+  pt spec's grapheme candidates
+"""
+import pytest
+from silabificador import syllabify
+
+import orthography2ipa
+from orthography2ipa.g2p_plugin import G2PPlugin
+from orthography2ipa.syllabifier_plugin import SyllabifierPlugin
+
+from tugaphone.dialects import EuropeanPortuguese
+from tugaphone.plugin import SilabificadorSyllabifier, TugaphoneG2PPlugin
+from tugaphone.tokenizer import detect_stress_position
+
+
+@pytest.fixture(scope="module")
+def dialect():
+    return EuropeanPortuguese()
+
+
+class TestStressDelegation:
+    @pytest.mark.parametrize("word,expected", [
+        # paroxytone default — including the unmarked -em/-am endings
+        # the old bare -m oxytone trigger got wrong
+        ("casa", 0), ("livro", 0), ("homem", 0), ("falam", 0),
+        ("viagem", 1),                 # vi-A-gem with real syllables
+        # oxytone endings
+        ("falar", 1), ("azul", 1), ("rapaz", 1), ("jardim", 1),
+        ("caju", 1), ("abacaxi", 3), ("atuns", 1),
+        # written accents win — circumflex included
+        ("médico", 0), ("lâmpada", 0), ("café", 1), ("túnel", 0),
+        ("órgão", 0), ("manhã", 1), ("amável", 1),
+        # monosyllables
+        ("sol", 0), ("pé", 0),
+    ])
+    def test_gold_positions(self, dialect, word, expected):
+        sylls = syllabify(word)
+        assert detect_stress_position(word, sylls, dialect) == expected
+
+    def test_spec_rules_present(self, dialect):
+        assert orthography2ipa.get(dialect.dialect_code).stress is not None
+
+
+class TestSyllabifierPlugin:
+    def test_implements_base(self):
+        assert isinstance(SilabificadorSyllabifier(), SyllabifierPlugin)
+
+    def test_registered_via_entry_point(self):
+        import orthography2ipa.registry as registry
+        registry._syllabifiers = None  # force re-discovery
+        plugin = orthography2ipa.get_syllabifier("pt-PT")
+        assert plugin is not None
+        assert type(plugin).__name__ == "SilabificadorSyllabifier"
+
+    def test_syllables_rebuild_word(self):
+        plugin = SilabificadorSyllabifier()
+        for word in ("viagem", "lâmpada", "abacaxi", "sol"):
+            sylls = plugin.syllabify(word, "pt-PT")
+            assert "".join(sylls) == word
+
+    def test_orthography2ipa_stress_uses_it(self):
+        """orthography2ipa's own detection gets real pt syllables."""
+        from orthography2ipa.stress import detect_stress
+
+        rules = orthography2ipa.get("pt-PT").stress
+        # naive splitter sees vi-a as one nucleus; silabificador fixes it
+        assert detect_stress("viagem", rules, lang="pt-PT") == 1
+
+
+class TestG2PPluginInterface:
+    def test_implements_base_lazily(self):
+        plugin = TugaphoneG2PPlugin()
+        assert isinstance(plugin, G2PPlugin)
+        assert plugin._phonemizer is None  # nothing heavy loaded yet
+        assert set(plugin.language_codes) >= {"pt-PT", "pt-BR"}
+
+
+class TestSpecParity:
+    """Audit hand-tuned single-char mappings against the pt spec data.
+
+    Informational gate: tugaphone's tables stay authoritative; this
+    pins the agreement level so spec-data drift is noticed.
+    """
+
+    def test_char2ipa_within_spec_candidates(self, dialect):
+        spec = orthography2ipa.get(dialect.dialect_code)
+        agree, differ = [], []
+        for char, ipa in dialect.DEFAULT_CHAR2PHONEMES.items():
+            candidates = spec.graphemes.get(char)
+            if candidates is None or not ipa:
+                continue
+            (agree if ipa in candidates else differ).append(
+                (char, ipa, candidates))
+        assert len(agree) >= 2 * len(differ), (
+            f"tugaphone and the pt spec diverged: {differ}"
+        )

--- a/tugaphone/ipa_transforms.py
+++ b/tugaphone/ipa_transforms.py
@@ -107,7 +107,7 @@ def conservative_o_nasal_retention(word: str, phonemes: str, postag: str = "NOUN
     """
     Preferentially realize final -ão as /õ/ to conservatively retain the older nasal vowel.
 
-    If the input word ends with "ão" and the phoneme string uses the merged nasal diphthong forms (`ˈɐ̃w` or `ˈɐ̃ʊ̃`), returns a phoneme string where that ending is replaced by `ˈõ`. Otherwise returns the original phoneme string unchanged.
+    If the input word ends with "ão" and the phoneme string uses the merged nasal diphthong forms (`ˈɐ̃w` or `ˈɐ̃ʊ̃`), returns a phoneme string where that ending is replaced by `ˈõ`. Otherwise returns the original phoneme string unchanged.
 
     Conservative Retention of /õ/ :
         Minho retains the older pronunciation of /õ/
@@ -115,12 +115,12 @@ def conservative_o_nasal_retention(word: str, phonemes: str, postag: str = "NOUN
         Examples include pão and irmão
 
     Returns:
-        The possibly modified phoneme string with final -ão realized as `ˈõ` when applicable.
+        The possibly modified phoneme string with final -ão realized as `ˈõ` when applicable.
     """
     if word.endswith("ão") and phonemes.endswith("ˈɐ̃w"):
-        return phonemes[:-4] + "ˈõ"
+        return phonemes[:-4] + "ˈõ"
     if word.endswith("ão") and phonemes.endswith("ˈɐ̃ʊ̃"):  # common espeak mistake
-        return phonemes[:-5] + "ˈõ"
+        return phonemes[:-5] + "ˈõ"
     return phonemes
 
 

--- a/tugaphone/plugin.py
+++ b/tugaphone/plugin.py
@@ -1,0 +1,74 @@
+"""tugaphone on the orthography2ipa base interfaces.
+
+tugaphone *consumes* orthography2ipa — its Portuguese spec data, the
+declarative stress rules and the shared
+:class:`~orthography2ipa.g2p_plugin.G2PPlugin`/``WordContext`` types —
+and owns the Portuguese pipeline (lexicon, POS tagging, gender-aware
+numbers, regional accent transforms). Use the engine directly:
+
+    >>> from tugaphone.plugin import TugaphoneG2PPlugin
+    >>> TugaphoneG2PPlugin().transcribe("o gato dorme")
+
+Two classes live here:
+
+- :class:`TugaphoneG2PPlugin` — the full phonemizer behind the shared
+  engine interface.
+- :class:`SilabificadorSyllabifier` — a component plugin registered in
+  the ``orthography2ipa.syllabify`` entry-point group, so
+  orthography2ipa's own stress detection syllabifies Portuguese with
+  ``silabificador`` instead of its naive vowel-group splitter.
+"""
+from typing import List, Optional
+
+from orthography2ipa.g2p_plugin import G2PPlugin, WordContext
+from orthography2ipa.syllabifier_plugin import SyllabifierPlugin
+from silabificador import syllabify as _syllabify
+
+_LANGS = ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]
+
+
+class TugaphoneG2PPlugin(G2PPlugin):
+    """Dialect-aware Portuguese G2P via the tugaphone pipeline.
+
+    The underlying :class:`tugaphone.TugaPhonemizer` (POS tagger +
+    lexicon) loads lazily on first transcription.
+    """
+
+    def __init__(self, lang: str = "pt-PT") -> None:
+        self.lang = lang
+        self._phonemizer = None
+
+    @property
+    def language_codes(self) -> List[str]:
+        return list(_LANGS)
+
+    def _engine(self):
+        if self._phonemizer is None:
+            from tugaphone import TugaPhonemizer
+            self._phonemizer = TugaPhonemizer()
+        return self._phonemizer
+
+    def transcribe(self, text: str) -> str:
+        return self._engine().phonemize_sentence(text, lang=self.lang)
+
+    def transcribe_word(
+        self, word: str, context: Optional[WordContext] = None
+    ) -> str:
+        lang = (context.lang if context is not None and context.lang
+                else self.lang)
+        if lang not in _LANGS:
+            lang = self.lang
+        return self._engine().phonemize_sentence(word, lang=lang)
+
+
+class SilabificadorSyllabifier(SyllabifierPlugin):
+    """Portuguese syllabifier for orthography2ipa's stress detection."""
+
+    @property
+    def language_codes(self) -> List[str]:
+        codes = list(_LANGS)
+        codes.extend(["pt-CV", "pt-GW", "pt-MO", "pt-ST", "pt-GQ"])
+        return codes
+
+    def syllabify(self, word: str, lang: Optional[str] = None) -> List[str]:
+        return list(_syllabify(word))

--- a/tugaphone/tokenizer.py
+++ b/tugaphone/tokenizer.py
@@ -72,7 +72,7 @@ QUICK REFERENCES:
 
 import dataclasses
 import string
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import List, Optional, Dict, Tuple
 
 from tugaphone.number_utils import normalize_numbers
@@ -85,15 +85,24 @@ from tugaphone.dialects import (DialectInventory, EuropeanPortuguese, BrazilianP
 # Helper Functions
 # =============================================================================
 
+@lru_cache(maxsize=None)
+def _spec_stress_rules(dialect_code: str):
+    """The declarative stress rules of the orthography2ipa spec, if any."""
+    try:
+        from orthography2ipa import get as _get_spec
+        return _get_spec(dialect_code).stress
+    except Exception:
+        return None
+
+
 def detect_stress_position(word: str, syllables: List[str], dialect: DialectInventory) -> int:
     """
     Determine which syllable carries primary stress.
 
-    ALGORITHM:
-    ----------
-    1. Check for explicit accent marks → stress that syllable
-    2. Check word-final pattern against OXYTONE_ENDINGS
-    3. Default to penultimate (paroxytone rule)
+    Delegates to the declarative ``StressRules`` of the dialect's
+    orthography2ipa spec (written accents → oxytone endings → penult
+    default). When the spec carries no stress block, the dialect's own
+    PRIMARY_STRESS_MARKERS / OXYTONE_ENDINGS apply.
 
     Args:
         word: Normalized word string
@@ -118,6 +127,11 @@ def detect_stress_position(word: str, syllables: List[str], dialect: DialectInve
     # Monosyllables are inherently stressed
     if n_syllables == 1:
         return 0
+
+    rules = _spec_stress_rules(dialect.dialect_code)
+    if rules is not None:
+        from orthography2ipa.stress import detect_stress
+        return detect_stress(word, rules, syllables=syllables)
 
     # Check for explicit accent marks (primary stress markers)
     for idx, syllable in enumerate(syllables):


### PR DESCRIPTION
## Summary
tugaphone becomes a **downstream Portuguese engine built on orthography2ipa** (the base library never loads external G2P engines — it gains *component* plugins instead).

- **Stress delegation**: `detect_stress_position` now consumes the declarative `StressRules` of the dialect's orthography2ipa spec (pt-PT/pt-BR seeded upstream in TigreGotico/orthography2ipa#23). This fixes real bugs in the hand-tuned tables: bare `-m`/`-n` oxytone triggers made *homem*/*falam* oxytone (they're paroxytone; `-im/-om/-um/-ns` are the real triggers), and circumflex vowels weren't stress markers (*lâmpada*). Hand-tuned fallback kept for dialects without a spec stress block. 21 gold stress cases pinned.
- **`SilabificadorSyllabifier`** registered in the `orthography2ipa.syllabify` entry-point group — the base library's own stress detection now syllabifies Portuguese with `silabificador` (resolves hiatus: *vi-a-gem*) instead of its naive vowel-group splitter.
- **`TugaphoneG2PPlugin`**: the full pipeline (POS tagging, lexicon, gender-aware numbers, regional transforms) behind the shared `G2PPlugin`/`WordContext` interface, with lazy tagger/lexicon loading. No G2P entry point — consumers import it directly.
- **Drive-by fixes**: `conservative_o_nasal_retention` emitted decomposed `o`+combining-tilde that never matched the precomposed `õ` comparisons (2 tests failed on dev); PEP 639 license-classifier conflict broke `pip install -e .` under new setuptools.
- Differential parity test pins the agreement between `DEFAULT_CHAR2PHONEMES` and the pt spec's grapheme candidates so data drift on either side is noticed.

## Testing
Full suite: **65 passed** (28 new; the 2 pre-existing NFC failures now pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Portuguese syllabification and phonetic transcription are now available as plugins for the orthography2ipa ecosystem.

* **Improvements**
  * Enhanced stress position detection with external declarative rules for improved accuracy on Portuguese words.
  * Updated conservative Portuguese phoneme handling for final nasal sounds.

* **Chores**
  * Added orthography2ipa dependency to enable plugin integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->