### PR TITLE
fix: restore final vowel in gosto VERB homograph IPA

### DIFF
--- a/tests/test_homographs_table.py
+++ b/tests/test_homographs_table.py
@@ -1,0 +1,17 @@
+"""Integrity checks for the POS-based HOMOGRAPHS table."""
+from tugaphone.dialects import EuropeanPortuguese
+
+
+def test_gosto_verb_keeps_final_vowel():
+    homographs = EuropeanPortuguese().HOMOGRAPHS
+    assert homographs["gosto"]["VERB"] == "ˈgɔʃtu"
+    assert homographs["gosto"]["NOUN"] == "ˈgoʃtu"
+
+
+def test_noun_verb_pairs_differ_only_in_vowel_quality():
+    """Each noun/verb pair must have the same length: the alternation is a
+    single open/closed vowel swap, never a dropped segment."""
+    homographs = EuropeanPortuguese().HOMOGRAPHS
+    for word, readings in homographs.items():
+        if "NOUN" in readings and "VERB" in readings:
+            assert len(readings["NOUN"]) == len(readings["VERB"]), word

--- a/tugaphone/dialects.py
+++ b/tugaphone/dialects.py
@@ -428,7 +428,7 @@ class DialectInventory:
             "coro": {"NOUN": "ˈkoɾu", "VERB": "ˈkɔɾu"}, # coro («conjunto de cantores») – coro (verbo corar);
             "corte": {"NOUN": "ˈkoɾtɨ", "VERB": "ˈkɔɾtɨ"}, # corte («morada do rei») – corte («ato de cortar»; verbo cortar);
             "gozo": {"NOUN": "ˈgozu", "VERB": "ˈgɔzu"}, # gozo («prazer»; «troça») – gozo (verbo gozar);
-            "gosto": {"NOUN": "ˈgoʃtu", "VERB": "ˈgɔʃt"}, #   gosto (substantivo) - gosto (1.ª pess.sing. pres. ind. - verbo gostar)
+            "gosto": {"NOUN": "ˈgoʃtu", "VERB": "ˈgɔʃtu"}, #   gosto (substantivo) - gosto (1.ª pess.sing. pres. ind. - verbo gostar)
             "jogo": {"NOUN": "ˈʒoɡu", "VERB": "ˈʒɔɡu"}, # jogo («divertimento») – jogo (verbo jogar);
             "molho": {"NOUN": "ˈmoʎu", "VERB": "ˈmɔʎu"}, # molho («líquido, caldo») – molho («feixe»; verbo molhar);
             "olho": {"NOUN": "ˈoʎu", "VERB": "ˈɔʎu"}, # olho («órgão da visão») – olho (verbo olhar);


### PR DESCRIPTION
`HOMOGRAPHS["gosto"]["VERB"]` was `ˈgɔʃt`, dropping the final `u` (`ˈgɔʃtu`). The truncation was latent because bifonia intercepts *gosto* before the POS table fires.

Adds `tests/test_homographs_table.py`: pins both *gosto* readings and asserts every NOUN/VERB pair in the table differs only by the open/closed vowel swap (equal length), which guards against this whole class of truncation.

Full suite: 207 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)