### PR TITLE
docs: tighten sede row wording in homographs table

### DIFF
--- a/docs/homographs.md
+++ b/docs/homographs.md
@@ -56,7 +56,7 @@ directly.
 | olho | ˈoʎu | ˈɔʎu | noun "eye" vs verb "I watch" |
 | peso | ˈpezu | ˈpɛzu | noun "weight" vs verb "I weigh" |
 | porto | ˈpoɾtu | ˈpɔɾtu | noun "port" vs verb "I carry" |
-| sede | ˈsɛdɨ | ˈsedɨ | headquarters (NOUN key) vs thirst (VERB key) — two noun senses sharing the noun/verb slots |
+| sede | ˈsɛdɨ | ˈsedɨ | headquarters (NOUN) vs thirst (VERB slot) |
 | colher | kuˈʎɛɾ | kuˈʎeɾ | noun "spoon" vs verb "to pick" |
 
 The full table is defined in `DialectInventory.HOMOGRAPHS` in


### PR DESCRIPTION
Applies the reviewer-suggested wording from #37: the *sede* table cell now states the slot mapping plainly (headquarters = NOUN, thirst = VERB slot) without implying the thirst sense is a verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)