### PR TITLE
feat: resolve every dialect, city inventory and regional preset from BCP-47 codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,24 +79,27 @@ print(ph.phonemize_sentence("Tenho bom gosto."))      # noun → ˈgoʃ·tu
 ### Sub-regional accents
 
 `RegionalTransforms` presets layer phonological rules on top of any dialect.
-Rules are grounded in published phonology (Cintra 1971; ALEPG):
+Rules are grounded in published phonology (Cintra 1971; ALEPG). Every preset
+is reachable by its BCP-47 private-use code:
 
 ```python
-from tugaphone.regional import PortoDialect, AzoresDialect
-
 # Porto: stressed /o/ → [uo] (rising diphthong)
-print(ph.phonemize_sentence("O vinho é muito bom.", "pt-PT", regional_dialect=PortoDialect))
+print(ph.phonemize_sentence("O vinho é muito bom.", "pt-PT-x-porto"))
 # ˈu bˈi·ɲu ˈɛ mˈũj·tu bˈuõ ˈ···
 
 # Açores: stressed /u/ → [y], l-palatalisation
-print(ph.phonemize_sentence("O vinho é muito bom.", "pt-PT", regional_dialect=AzoresDialect))
+print(ph.phonemize_sentence("O vinho é muito bom.", "pt-PT-x-azores"))
 # ˈy vˈi·ɲu ˈɛ mˈỹj·tu bˈõ ˈ···
+
+from tugaphone import list_dialects
+print(list_dialects())   # all 20 registered codes
 ```
 
 Available presets: `NorthernDialect`, `PortoDialect`, `MinhoDialect`,
 `BragaDialect`, `FamalicaoDialect`, `FafeDialect`, `TrasMontanoDialect`,
 `CoimbraDialect`, `AlentejoDialect`, `AlgarveDialect`, `MadeiraDialect`,
-`AzoresDialect`.
+`AzoresDialect` — importable from `tugaphone.regional` and passable as
+`regional_dialect=`, which overrides the code-derived preset.
 
 ### Number normalization
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -31,11 +31,15 @@ Transcribes `sentence` to IPA for the target dialect. Returns a space-separated
 phoneme string — one token per word, with `ˈ` for primary stress and `·` for
 syllable boundaries; punctuation tokens are preserved.
 
-`lang` is one of `pt-PT`, `pt-BR`, `pt-AO`, `pt-MZ`, `pt-TL`; any other value
-falls back to European Portuguese.
+`lang` is any code from `list_dialects()` — the five majors (`pt-PT`, `pt-BR`,
+`pt-AO`, `pt-MZ`, `pt-TL`), the city inventories (`pt-BR-x-sao-paulo`, …) and
+the regional accent presets (`pt-PT-x-porto`, …). Resolution is
+case-insensitive with alias support; unknown codes fall back to European
+Portuguese. See [dialects.md](dialects.md#dialect-codes).
 
 When `regional_dialect` is given, the word is first run through the preset's
-morpheme rules, transcribed, then run through its IPA rules. See
+morpheme rules, transcribed, then run through its IPA rules; an explicit
+preset overrides whatever `lang` resolves to. See
 [`RegionalTransforms`](#tugaphoneregionalregionaltransforms).
 
 ```python
@@ -49,9 +53,31 @@ ph.phonemize_sentence("O gato dorme.", "pt-BR")   # 'ˈu gˈa·tʊ ˈdoɾ·mɪ �
 TugaPhonemizer.get_dialect_inventory(lang: str = "pt-PT") -> DialectInventory
 ```
 
-Maps a dialect code to its `DialectInventory` instance (`EuropeanPortuguese`,
-`BrazilianPortuguese`, `AngolanPortuguese`, `MozambicanPortuguese`,
-`TimoresePortuguese`).
+Maps a dialect code to a fresh `DialectInventory` instance through the
+dialect registry (`EuropeanPortuguese`, `BrazilianPortuguese`,
+`AngolanPortuguese`, `MozambicanPortuguese`, `TimoresePortuguese`, plus the
+city inventories `LisbonPortuguese`, `RioJaneiroPortuguese`,
+`SaoPauloPortuguese`).
+
+## `tugaphone.registry`
+
+The dialect registry behind code resolution. The first three are re-exported
+from the package root.
+
+| Symbol | Role |
+|--------|------|
+| `resolve_dialect(lang)` | Resolve any BCP-47 code (case-insensitive, alias-aware) to its `DialectEntry`; unknown codes fall back to the parent tag, then `pt-PT`. |
+| `list_dialects()` | Sorted list of all canonical dialect codes. |
+| `DialectEntry` | Frozen record: `code`, `inventory` (class), `transforms` (preset or `None`), `region`, `aliases`. |
+| `get_regional_transforms(lang)` | The `RegionalTransforms` preset for a code, or `None`. |
+| `normalize_dialect_code(lang)` | BCP-47 case normalization (`PT-pt-X-PORTO` → `pt-PT-x-porto`). |
+
+```python
+from tugaphone import resolve_dialect, list_dialects
+
+resolve_dialect("pt-PT-x-porto").region   # 'Porto / Douro Litoral'
+len(list_dialects())                      # 20
+```
 
 ## `tugaphone.number_utils`
 
@@ -125,9 +151,12 @@ clone = RegionalTransforms.from_dict(cfg)
 
 ### Preset accents
 
-Importable from `tugaphone.regional`: `CoimbraDialect`, `MinhoDialect`,
-`BragaDialect`, `FamalicaoDialect`, `TrasMontanoDialect`, `PortoDialect`,
-`FafeDialect`. Each is a ready-built `RegionalTransforms`. Pass any of them to
+Importable from `tugaphone.regional`: `NorthernDialect`, `CoimbraDialect`,
+`MinhoDialect`, `BragaDialect`, `FamalicaoDialect`, `TrasMontanoDialect`,
+`PortoDialect`, `FafeDialect`, `AlentejoDialect`, `AlgarveDialect`,
+`MadeiraDialect`, `AzoresDialect`. Each is a ready-built `RegionalTransforms`,
+reachable by its dialect code (see the
+[preset table](dialects.md#preset-table)) or passed explicitly to
 `phonemize_sentence(..., regional_dialect=...)`.
 
 Only the IPA rules listed in `RULE_MAP` round-trip through `as_dict`/`from_dict`;
@@ -139,6 +168,7 @@ accents built from other rule functions serialize a subset.
 |--------|------|
 | `DialectInventory` | Base class: phoneme maps, character sets, stress/punctuation tokens. `dialect_code` attribute carries the tag. |
 | `EuropeanPortuguese`, `BrazilianPortuguese`, `AngolanPortuguese`, `MozambicanPortuguese`, `TimoresePortuguese` | The five dialect inventories. |
+| `LisbonPortuguese`, `RioJaneiroPortuguese`, `SaoPauloPortuguese` | City-level inventories backed by their own lexicon region maps. |
 | `LEXICON` | Module-level `TugaLexicon()` instance; lazy-loaded on first use and warmed by `TugaPhonemizer.__init__`. |
 
 You rarely instantiate these directly — `TugaPhonemizer` does it for you — but
@@ -172,7 +202,7 @@ Implements `orthography2ipa.g2p_plugin.G2PPlugin`. The underlying
 
 | Member | Description |
 |--------|-------------|
-| `language_codes` | `["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]` |
+| `language_codes` | `list_dialects()` — every registered code, majors and regional accents alike. |
 | `transcribe(text)` | Phonemize a full sentence. |
 | `transcribe_word(word, context=None)` | Phonemize a single word; `context.lang` overrides `self.lang`. |
 

--- a/docs/dialects.md
+++ b/docs/dialects.md
@@ -19,8 +19,6 @@ for code in ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
 # pt-TL → ʃo·ˈvew mˈuj·tʊ ˈõ·tẽ ˈ···
 ```
 
-Any unrecognised tag falls back to European Portuguese.
-
 ### pt-PT — European Portuguese
 
 `EuropeanPortuguese`. The Lisbon standard is the base inventory:
@@ -56,16 +54,55 @@ Any unrecognised tag falls back to European Portuguese.
 `TimoresePortuguese`. Second language for most speakers; influenced by Tetum
 and other Austronesian languages. Conservative consonantism, /u/ not fronted.
 
+## Dialect codes
+
+Every supported dialect — the five majors, the city-level inventories and the
+regional accent presets below — resolves from a single registry by BCP-47
+code. Regional accents use private-use subtags (`pt-PT-x-porto`), the
+convention shared across the phonetics stack:
+
+```python
+from tugaphone import list_dialects, resolve_dialect
+
+print(list_dialects())
+# ['pt-AO', 'pt-BR', 'pt-BR-x-rio-janeiro', 'pt-BR-x-sao-paulo', 'pt-MZ',
+#  'pt-PT', 'pt-PT-x-alentejo', 'pt-PT-x-algarve', 'pt-PT-x-azores',
+#  'pt-PT-x-braga', 'pt-PT-x-coimbra', 'pt-PT-x-fafe', 'pt-PT-x-famalicao',
+#  'pt-PT-x-lisbon', 'pt-PT-x-madeira', 'pt-PT-x-minho', 'pt-PT-x-north',
+#  'pt-PT-x-porto', 'pt-PT-x-transmontano', 'pt-TL']
+
+entry = resolve_dialect("pt-PT-x-porto")
+print(entry.region)   # Porto / Douro Litoral
+```
+
+Resolution is case-insensitive and accepts common aliases (`pt`,
+`pt-PT-x-lisboa`, `pt-PT-x-acores`, `pt-PT-x-tras-os-montes`,
+`pt-PT-x-central`, `pt-BR-x-rio`, `pt-PT-x-norte`). An unknown private-use
+subtag falls back to its parent (`pt-PT-x-anything` → `pt-PT`); any other
+unrecognised tag falls back to European Portuguese.
+
+### City inventories
+
+Three city-level `DialectInventory` subclasses carry their own lexicon
+region maps: `pt-PT-x-lisbon` (`LisbonPortuguese`), `pt-BR-x-rio-janeiro`
+(`RioJaneiroPortuguese`) and `pt-BR-x-sao-paulo` (`SaoPauloPortuguese`).
+
+```python
+print(ph.phonemize_sentence("noite", "pt-BR"))             # nˈoj·tʃɪ
+print(ph.phonemize_sentence("noite", "pt-BR-x-sao-paulo")) # nˈoj·tʃi
+```
+
 ---
 
 ## Sub-regional accent presets
 
-On top of any dialect code, you can layer a `RegionalTransforms` preset via
-the `regional_dialect` argument. Every preset is a composition of grounded
-phonological rules cited to published sources (Cintra 1971; ALEPG 2006).
+Each preset is a composition of grounded phonological rules cited to
+published sources (Cintra 1971; ALEPG 2006). Reach one through its dialect
+code, or layer any preset explicitly via the `regional_dialect` argument —
+the explicit argument wins over whatever the code resolves to:
 
 ```python
-from tugaphone.regional import PortoDialect, AzoresDialect
+from tugaphone.regional import AzoresDialect
 
 ph = TugaPhonemizer()
 s = "O vinho é muito bom."
@@ -73,7 +110,7 @@ s = "O vinho é muito bom."
 print(ph.phonemize_sentence(s, "pt-PT"))
 # pt-PT standard: ˈu vˈi·ɲu ˈɛ mˈũj·tu bˈõ ˈ···
 
-print(ph.phonemize_sentence(s, "pt-PT", regional_dialect=PortoDialect))
+print(ph.phonemize_sentence(s, "pt-PT-x-porto"))
 # Porto: ˈu bˈi·ɲu ˈɛ mˈũj·tu bˈuõ ˈ···  (betacism + rising diphthong)
 
 print(ph.phonemize_sentence(s, "pt-PT", regional_dialect=AzoresDialect))
@@ -84,20 +121,20 @@ print(ph.phonemize_sentence(s, "pt-PT", regional_dialect=AzoresDialect))
 
 All presets are importable from `tugaphone.regional`.
 
-| Preset | Region | Signature rules |
-|--------|--------|-----------------|
-| `NorthernDialect` | Northern Portugal (generic) | `<ou>/<ei>` retention, betacism /v/→[b] |
-| `CoimbraDialect` | Coimbra / Centro-Litoral | `<ou>/<ei>` retention, no betacism |
-| `PortoDialect` | Porto / Douro Litoral | Stressed /o/→[uo] rising diphthong + northern core |
-| `MinhoDialect` | Minho (conservative rural) | Vowel-centralisation resistance, open /a/, alveolar [r] |
-| `BragaDialect` | Braga | Palatal epenthesis (`abelha`→`abeilha`) + Minho |
-| `FamalicaoDialect` | Vila Nova de Famalicão | Conservative `-ão`→[õ] retention + Minho |
-| `FafeDialect` | Fafe / inner Minho | Nasal /ẽ/→[eĩ] diphthongisation + Minho |
-| `TrasMontanoDialect` | Trás-os-Montes | `<ch>` affrication, s-voicing, nasal denasalisation |
-| `AlentejoDialect` | Alentejo | Intervocalic /d/ deletion, `meu`→[me], `ei`→[e] |
-| `AlgarveDialect` | Algarve | `meu`→[me], coda-sibilant voicing sandhi |
-| `MadeiraDialect` | Madeira | l-palatalisation, nasal diphthong → Ṽ+[n] |
-| `AzoresDialect` | Açores (São Miguel) | Stressed /u/→[y], l-palatalisation, `oi`→[o] |
+| Code | Preset | Region | Signature rules |
+|------|--------|--------|-----------------|
+| `pt-PT-x-north` | `NorthernDialect` | Northern Portugal (generic) | `<ou>/<ei>` retention, betacism /v/→[b] |
+| `pt-PT-x-coimbra` | `CoimbraDialect` | Coimbra / Centro-Litoral | `<ou>/<ei>` retention, no betacism |
+| `pt-PT-x-porto` | `PortoDialect` | Porto / Douro Litoral | Stressed /o/→[uo] rising diphthong + northern core |
+| `pt-PT-x-minho` | `MinhoDialect` | Minho (conservative rural) | Vowel-centralisation resistance, open /a/, alveolar [r] |
+| `pt-PT-x-braga` | `BragaDialect` | Braga | Palatal epenthesis (`abelha`→`abeilha`) + Minho |
+| `pt-PT-x-famalicao` | `FamalicaoDialect` | Vila Nova de Famalicão | Conservative `-ão`→[õ] retention + Minho |
+| `pt-PT-x-fafe` | `FafeDialect` | Fafe / inner Minho | Nasal /ẽ/→[eĩ] diphthongisation + Minho |
+| `pt-PT-x-transmontano` | `TrasMontanoDialect` | Trás-os-Montes | `<ch>` affrication, s-voicing, nasal denasalisation |
+| `pt-PT-x-alentejo` | `AlentejoDialect` | Alentejo | Intervocalic /d/ deletion, `meu`→[me], `ei`→[e] |
+| `pt-PT-x-algarve` | `AlgarveDialect` | Algarve | `meu`→[me], coda-sibilant voicing sandhi |
+| `pt-PT-x-madeira` | `MadeiraDialect` | Madeira | l-palatalisation, nasal diphthong → Ṽ+[n] |
+| `pt-PT-x-azores` | `AzoresDialect` | Açores (São Miguel) | Stressed /u/→[y], l-palatalisation, `oi`→[o] |
 
 ### Building a custom accent
 

--- a/examples/10_dialect_registry.py
+++ b/examples/10_dialect_registry.py
@@ -1,0 +1,35 @@
+"""Example — the dialect registry: every dialect reachable by language code.
+
+Major dialects, city inventories and regional accent presets all resolve from
+BCP-47 codes; regional accents use private-use subtags (``pt-PT-x-porto``).
+
+Run::
+
+    python examples/10_dialect_registry.py
+"""
+from tugaphone import TugaPhonemizer, list_dialects, resolve_dialect
+
+
+def main() -> None:
+    print("Registered dialect codes:")
+    for code in list_dialects():
+        entry = resolve_dialect(code)
+        kind = "preset" if entry.transforms else "inventory"
+        print(f"  {code:24s} {kind:9s} {entry.region}")
+
+    ph = TugaPhonemizer()
+    sentence = "O vinho é muito bom."
+
+    print(f"\n{sentence}")
+    for code in ["pt-PT", "pt-PT-x-porto", "pt-PT-x-alentejo",
+                 "pt-PT-x-azores", "pt-BR", "pt-BR-x-sao-paulo"]:
+        print(f"  {code:20s} → {ph.phonemize_sentence(sentence, code)}")
+
+    # Aliases and unknown subtags resolve sanely.
+    print("\nResolution:")
+    for code in ["pt", "PT-BR", "pt-PT-x-lisboa", "pt-PT-x-unknown"]:
+        print(f"  {code:18s} → {resolve_dialect(code).code}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -20,7 +20,7 @@ def _run(script: Path) -> subprocess.CompletedProcess:
 
 
 def test_all_examples_exist():
-    assert len(EXAMPLES) >= 9, f"Expected at least 9 examples, found {len(EXAMPLES)}"
+    assert len(EXAMPLES) >= 10, f"Expected at least 10 examples, found {len(EXAMPLES)}"
 
 
 def test_01_basic():
@@ -65,4 +65,9 @@ def test_08_rules_only():
 
 def test_09_plugin():
     r = _run(EXAMPLES_DIR / "09_plugin.py")
+    assert r.returncode == 0, r.stderr
+
+
+def test_10_dialect_registry():
+    r = _run(EXAMPLES_DIR / "10_dialect_registry.py")
     assert r.returncode == 0, r.stderr

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,161 @@
+"""Dialect registry: code resolution, listing and phonemizer integration.
+
+Every pinned IPA string in this file was captured by running the phonemizer.
+"""
+
+import pytest
+
+from tugaphone.dialects import (EuropeanPortuguese, LisbonPortuguese,
+                                BrazilianPortuguese, RioJaneiroPortuguese,
+                                SaoPauloPortuguese, AngolanPortuguese,
+                                MozambicanPortuguese, TimoresePortuguese)
+from tugaphone.regional import (NorthernDialect, PortoDialect, MinhoDialect,
+                                BragaDialect, FamalicaoDialect, FafeDialect,
+                                TrasMontanoDialect, CoimbraDialect,
+                                AlentejoDialect, AlgarveDialect,
+                                MadeiraDialect, AzoresDialect)
+from tugaphone.registry import (DIALECT_REGISTRY, DialectEntry,
+                                normalize_dialect_code, resolve_dialect,
+                                get_dialect_inventory, get_regional_transforms,
+                                list_dialects)
+
+
+class TestNormalization:
+    def test_casing(self):
+        assert normalize_dialect_code("PT-pt-X-PORTO") == "pt-PT-x-porto"
+
+    def test_major(self):
+        assert normalize_dialect_code("pt-br") == "pt-BR"
+
+    def test_bare(self):
+        assert normalize_dialect_code("PT") == "pt"
+
+
+class TestResolution:
+    @pytest.mark.parametrize("code,inventory", [
+        ("pt-PT", EuropeanPortuguese),
+        ("pt-BR", BrazilianPortuguese),
+        ("pt-AO", AngolanPortuguese),
+        ("pt-MZ", MozambicanPortuguese),
+        ("pt-TL", TimoresePortuguese),
+        ("pt-PT-x-lisbon", LisbonPortuguese),
+        ("pt-BR-x-rio-janeiro", RioJaneiroPortuguese),
+        ("pt-BR-x-sao-paulo", SaoPauloPortuguese),
+    ])
+    def test_inventory_codes(self, code, inventory):
+        entry = resolve_dialect(code)
+        assert entry.code == code
+        assert entry.inventory is inventory
+        assert isinstance(get_dialect_inventory(code), inventory)
+
+    @pytest.mark.parametrize("code,preset", [
+        ("pt-PT-x-north", NorthernDialect),
+        ("pt-PT-x-porto", PortoDialect),
+        ("pt-PT-x-minho", MinhoDialect),
+        ("pt-PT-x-braga", BragaDialect),
+        ("pt-PT-x-famalicao", FamalicaoDialect),
+        ("pt-PT-x-fafe", FafeDialect),
+        ("pt-PT-x-transmontano", TrasMontanoDialect),
+        ("pt-PT-x-coimbra", CoimbraDialect),
+        ("pt-PT-x-alentejo", AlentejoDialect),
+        ("pt-PT-x-algarve", AlgarveDialect),
+        ("pt-PT-x-madeira", MadeiraDialect),
+        ("pt-PT-x-azores", AzoresDialect),
+    ])
+    def test_preset_codes(self, code, preset):
+        entry = resolve_dialect(code)
+        assert entry.transforms is preset
+        assert entry.inventory is EuropeanPortuguese
+        assert get_regional_transforms(code) is preset
+
+    @pytest.mark.parametrize("alias,canonical", [
+        ("pt", "pt-PT"),
+        ("pt-PT-x-lisboa", "pt-PT-x-lisbon"),
+        ("pt-BR-x-rio", "pt-BR-x-rio-janeiro"),
+        ("pt-PT-x-norte", "pt-PT-x-north"),
+        ("pt-PT-x-tras-os-montes", "pt-PT-x-transmontano"),
+        ("pt-PT-x-central", "pt-PT-x-coimbra"),
+        ("pt-PT-x-acores", "pt-PT-x-azores"),
+    ])
+    def test_aliases(self, alias, canonical):
+        assert resolve_dialect(alias).code == canonical
+
+    def test_case_insensitive(self):
+        assert resolve_dialect("PT-BR").inventory is BrazilianPortuguese
+        assert resolve_dialect("pt-pt-X-PORTO").transforms is PortoDialect
+
+    def test_unknown_private_use_falls_back_to_parent(self):
+        entry = resolve_dialect("pt-PT-x-unknown")
+        assert entry.code == "pt-PT"
+        assert entry.transforms is None
+
+    def test_unknown_language_falls_back_to_default(self):
+        assert resolve_dialect("fr").code == "pt-PT"
+        assert resolve_dialect("").code == "pt-PT"
+
+    def test_majors_have_no_preset(self):
+        for code in ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
+            assert get_regional_transforms(code) is None
+
+    def test_fresh_inventory_per_resolution(self):
+        assert get_dialect_inventory("pt-PT") is not get_dialect_inventory("pt-PT")
+
+
+class TestListDialects:
+    def test_sorted_canonical_no_aliases(self):
+        codes = list_dialects()
+        assert codes == sorted(codes)
+        assert "pt-PT" in codes and "pt-PT-x-porto" in codes
+        assert "pt" not in codes and "pt-PT-x-lisboa" not in codes
+        assert len(codes) == len(DIALECT_REGISTRY)
+
+    def test_plugin_exposes_registry(self):
+        from tugaphone.plugin import TugaphoneG2PPlugin
+        assert TugaphoneG2PPlugin().language_codes == list_dialects()
+
+    def test_entries_are_frozen(self):
+        entry = resolve_dialect("pt-PT")
+        with pytest.raises(Exception):
+            entry.code = "other"
+        assert isinstance(entry, DialectEntry)
+
+
+@pytest.fixture(scope="module")
+def pho():
+    from tugaphone import TugaPhonemizer
+    return TugaPhonemizer()
+
+
+class TestPhonemizerIntegration:
+    SENTENCE = "Choveu muito ontem à noite."
+
+    def test_preset_code_equals_manual_kwarg(self, pho):
+        via_code = pho.phonemize_sentence(self.SENTENCE, "pt-PT-x-porto")
+        via_kwarg = pho.phonemize_sentence(self.SENTENCE, "pt-PT",
+                                           regional_dialect=PortoDialect)
+        assert via_code == via_kwarg
+        assert via_code == "ʃu·ˈbew mˈũj·tu ˈõ·tẽ ˈa nˈoj·tɨ ˈ···"
+
+    def test_explicit_kwarg_overrides_code(self, pho):
+        override = pho.phonemize_sentence(self.SENTENCE, "pt-PT-x-porto",
+                                          regional_dialect=AzoresDialect)
+        pure = pho.phonemize_sentence(self.SENTENCE, "pt-PT-x-azores")
+        assert override == pure
+
+    def test_city_inventory_differs_from_major(self, pho):
+        assert pho.phonemize_sentence("noite", "pt-BR") == "nˈoj·tʃɪ"
+        assert pho.phonemize_sentence("noite", "pt-BR-x-sao-paulo") == "nˈoj·tʃi"
+
+    @pytest.mark.parametrize("code,expected", [
+        ("pt-PT", "ʃu·ˈvew mˈũj·tu ˈõ·tẽ ˈa nˈoj·tɨ ˈ···"),
+        ("pt-BR", "ʃo·ˈvew mwˈĩ·tʊ ˈõ·tẽ ˈa nˈoj·tʃɪ ˈ···"),
+        ("pt-AO", "ʃo·ˈvew mˈũjn·tʊ ˈõ·tẽ ˈa nˈoj·tɨ ˈ···"),
+        ("pt-MZ", "ʃu·ˈvew mˈũj·tu ˈõ·tẽ ˈa nˈɔj·tɨ ˈ···"),
+        ("pt-TL", "ʃo·ˈvew mˈuj·tʊ ˈõ·tẽ ˈa nˈojtʰ ˈ···"),
+    ])
+    def test_major_dialect_output_unchanged(self, pho, code, expected):
+        assert pho.phonemize_sentence(self.SENTENCE, code) == expected
+
+    def test_unrecognised_tag_matches_default(self, pho):
+        assert (pho.phonemize_sentence(self.SENTENCE, "pt-PT-x-nowhere")
+                == pho.phonemize_sentence(self.SENTENCE, "pt-PT"))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -30,6 +30,9 @@ class TestNormalization:
     def test_bare(self):
         assert normalize_dialect_code("PT") == "pt"
 
+    def test_private_use_subtags_stay_lowercase(self):
+        assert normalize_dialect_code("pt-BR-X-SP") == "pt-BR-x-sp"
+
 
 class TestResolution:
     @pytest.mark.parametrize("code,inventory", [

--- a/tugaphone/__init__.py
+++ b/tugaphone/__init__.py
@@ -7,6 +7,9 @@ from tugaphone.dialects import (DialectInventory, LEXICON,
 from tugalex import TugaLexicon
 from tugatagger import TugaTagger
 from tugaphone.regional import RegionalTransforms
+from tugaphone.registry import (DialectEntry, resolve_dialect, list_dialects,
+                                get_regional_transforms)
+from tugaphone.registry import get_dialect_inventory as _registry_inventory
 from tugaphone.tokenizer import Sentence, DialectInventory
 
 try:
@@ -23,12 +26,11 @@ class TugaPhonemizer:
     """
     TugaPhonemizer applies dialect-aware Portuguese phonemization.
 
-    Supports:
-        - pt-PT (Portugal)
-        - pt-BR (Brazil)
-        - pt-AO (Angola)
-        - pt-MZ (Mozambique)
-        - pt-TL (Timor-Leste)
+    Supports the five major Lusophone dialects (pt-PT, pt-BR, pt-AO, pt-MZ,
+    pt-TL), city-level inventories (pt-PT-x-lisbon, pt-BR-x-rio-janeiro,
+    pt-BR-x-sao-paulo) and the regional accent presets reachable through
+    BCP-47 private-use codes (pt-PT-x-porto, pt-PT-x-alentejo, …); the full
+    list comes from :func:`tugaphone.list_dialects`.
     """
 
     def __init__(self,
@@ -47,15 +49,8 @@ class TugaPhonemizer:
 
     @staticmethod
     def get_dialect_inventory(lang: str = "pt-PT") -> DialectInventory:
-        if lang == "pt-BR":
-            return BrazilianPortuguese()
-        elif lang == "pt-AO":
-            return AngolanPortuguese()
-        elif lang == "pt-MZ":
-            return MozambicanPortuguese()
-        elif lang == "pt-TL":
-            return TimoresePortuguese()
-        return EuropeanPortuguese()
+        """Return the :class:`DialectInventory` registered for ``lang``."""
+        return _registry_inventory(lang)
 
     def phonemize_sentence(self, sentence: str, lang: str = "pt-PT",
                            regional_dialect: Optional[RegionalTransforms] = None) -> str:
@@ -64,7 +59,13 @@ class TugaPhonemizer:
 
         Parameters:
             sentence (str): Input sentence to phonemize.
-            lang (str): ISO dialect code to target (e.g., "pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL").
+            lang (str): BCP-47 dialect code to target. Major dialects
+                ("pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"), city
+                inventories ("pt-BR-x-sao-paulo", …) and regional accent
+                presets ("pt-PT-x-porto", …) all resolve through the
+                dialect registry; see :func:`tugaphone.list_dialects`.
+            regional_dialect (RegionalTransforms): Explicit regional accent
+                preset; overrides whatever preset ``lang`` resolves to.
 
         Returns:
             phonemized (str): Space-separated phoneme tokens for each word; punctuation tokens are preserved unchanged.
@@ -76,6 +77,7 @@ class TugaPhonemizer:
 
         tagged = self.postag.tag(sentence)
 
+        regional_dialect = regional_dialect or get_regional_transforms(lang)
         if regional_dialect:
             # 1. apply morpheme transforms
             morph = lambda tok, pos: regional_dialect.apply_morpheme(word=tok, postag=pos)
@@ -98,8 +100,6 @@ class TugaPhonemizer:
 
 
 if __name__ == "__main__":
-    from tugaphone.regional import PortoDialect
-
     ph = TugaPhonemizer()
 
     sentences = [
@@ -117,7 +117,6 @@ if __name__ == "__main__":
 
     for s in sentences:
         print(s)
-        print(f"pt-PT-x-porto → {ph.phonemize_sentence(s, regional_dialect=PortoDialect)}")
-        for code in ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
+        for code in ["pt-PT", "pt-PT-x-porto", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]:
             print(f"{code} → {ph.phonemize_sentence(s, code)}")
         print("######")

--- a/tugaphone/plugin.py
+++ b/tugaphone/plugin.py
@@ -24,7 +24,9 @@ from orthography2ipa.g2p_plugin import G2PPlugin, WordContext
 from orthography2ipa.syllabifier_plugin import SyllabifierPlugin
 from silabificador import syllabify as _syllabify
 
-_LANGS = ["pt-PT", "pt-BR", "pt-AO", "pt-MZ", "pt-TL"]
+from tugaphone.registry import list_dialects
+
+_LANGS = list_dialects()
 
 
 class TugaphoneG2PPlugin(G2PPlugin):
@@ -56,8 +58,6 @@ class TugaphoneG2PPlugin(G2PPlugin):
     ) -> str:
         lang = (context.lang if context is not None and context.lang
                 else self.lang)
-        if lang not in _LANGS:
-            lang = self.lang
         return self._engine().phonemize_sentence(word, lang=lang)
 
 

--- a/tugaphone/plugin.py
+++ b/tugaphone/plugin.py
@@ -26,8 +26,6 @@ from silabificador import syllabify as _syllabify
 
 from tugaphone.registry import list_dialects
 
-_LANGS = list_dialects()
-
 
 class TugaphoneG2PPlugin(G2PPlugin):
     """Dialect-aware Portuguese G2P via the tugaphone pipeline.
@@ -42,7 +40,7 @@ class TugaphoneG2PPlugin(G2PPlugin):
 
     @property
     def language_codes(self) -> List[str]:
-        return list(_LANGS)
+        return list_dialects()
 
     def _engine(self):
         if self._phonemizer is None:
@@ -66,7 +64,7 @@ class SilabificadorSyllabifier(SyllabifierPlugin):
 
     @property
     def language_codes(self) -> List[str]:
-        codes = list(_LANGS)
+        codes = list_dialects()
         codes.extend(["pt-CV", "pt-GW", "pt-MO", "pt-ST", "pt-GQ"])
         return codes
 

--- a/tugaphone/registry.py
+++ b/tugaphone/registry.py
@@ -1,0 +1,149 @@
+"""Dialect registry: resolve BCP-47 language codes to inventories and presets.
+
+Maps every supported language code — the five major Lusophone dialects, the
+city-level inventories and the regional accent presets — to a
+:class:`~tugaphone.dialects.DialectInventory` class and, where one applies, a
+:class:`~tugaphone.regional.RegionalTransforms` preset. Regional accents use
+BCP-47 private-use subtags (``pt-PT-x-porto``), the convention shared across
+the phonetics stack.
+
+    >>> from tugaphone.registry import resolve_dialect, list_dialects
+    >>> resolve_dialect("pt-PT-x-porto").transforms is not None
+    True
+    >>> "pt-BR-x-sao-paulo" in list_dialects()
+    True
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+from tugaphone.dialects import (DialectInventory, EuropeanPortuguese,
+                                LisbonPortuguese, BrazilianPortuguese,
+                                RioJaneiroPortuguese, SaoPauloPortuguese,
+                                AngolanPortuguese, MozambicanPortuguese,
+                                TimoresePortuguese)
+from tugaphone.regional import (RegionalTransforms, NorthernDialect,
+                                PortoDialect, MinhoDialect, BragaDialect,
+                                FamalicaoDialect, FafeDialect,
+                                TrasMontanoDialect, CoimbraDialect,
+                                AlentejoDialect, AlgarveDialect,
+                                MadeiraDialect, AzoresDialect)
+
+
+@dataclass(frozen=True)
+class DialectEntry:
+    """A registered dialect: its canonical code, inventory and optional preset.
+
+    Attributes:
+        code: Canonical BCP-47 tag (private-use subtags for regional accents).
+        inventory: :class:`DialectInventory` subclass; called to get a fresh
+            inventory instance on every resolution.
+        transforms: Regional accent preset applied on top of the inventory,
+            or ``None`` when the inventory alone defines the dialect.
+        region: Human-readable label.
+        aliases: Alternative codes that resolve to this entry.
+    """
+    code: str
+    inventory: Callable[[], DialectInventory]
+    transforms: Optional[RegionalTransforms] = None
+    region: str = ""
+    aliases: Tuple[str, ...] = ()
+
+
+_ENTRIES: Tuple[DialectEntry, ...] = (
+    # Major Lusophone dialects — inventory-defined.
+    DialectEntry("pt-PT", EuropeanPortuguese, region="Portugal (Lisbon standard)",
+                 aliases=("pt",)),
+    DialectEntry("pt-BR", BrazilianPortuguese, region="Brazil"),
+    DialectEntry("pt-AO", AngolanPortuguese, region="Angola (Luanda)"),
+    DialectEntry("pt-MZ", MozambicanPortuguese, region="Mozambique (Maputo)"),
+    DialectEntry("pt-TL", TimoresePortuguese, region="Timor-Leste"),
+    # City-level inventories backed by their own lexicon region maps.
+    DialectEntry("pt-PT-x-lisbon", LisbonPortuguese, region="Lisbon",
+                 aliases=("pt-PT-x-lisboa",)),
+    DialectEntry("pt-BR-x-rio-janeiro", RioJaneiroPortuguese,
+                 region="Rio de Janeiro", aliases=("pt-BR-x-rio",)),
+    DialectEntry("pt-BR-x-sao-paulo", SaoPauloPortuguese, region="São Paulo"),
+    # Regional accent presets — grounded rule compositions over the
+    # European Portuguese base (see tugaphone.regional).
+    DialectEntry("pt-PT-x-north", EuropeanPortuguese, NorthernDialect,
+                 region="Northern Portugal", aliases=("pt-PT-x-norte",)),
+    DialectEntry("pt-PT-x-porto", EuropeanPortuguese, PortoDialect,
+                 region="Porto / Douro Litoral"),
+    DialectEntry("pt-PT-x-minho", EuropeanPortuguese, MinhoDialect,
+                 region="Minho"),
+    DialectEntry("pt-PT-x-braga", EuropeanPortuguese, BragaDialect,
+                 region="Braga"),
+    DialectEntry("pt-PT-x-famalicao", EuropeanPortuguese, FamalicaoDialect,
+                 region="Vila Nova de Famalicão"),
+    DialectEntry("pt-PT-x-fafe", EuropeanPortuguese, FafeDialect,
+                 region="Fafe"),
+    DialectEntry("pt-PT-x-transmontano", EuropeanPortuguese, TrasMontanoDialect,
+                 region="Trás-os-Montes", aliases=("pt-PT-x-tras-os-montes",)),
+    DialectEntry("pt-PT-x-coimbra", EuropeanPortuguese, CoimbraDialect,
+                 region="Coimbra / Centro-Litoral", aliases=("pt-PT-x-central",)),
+    DialectEntry("pt-PT-x-alentejo", EuropeanPortuguese, AlentejoDialect,
+                 region="Alentejo"),
+    DialectEntry("pt-PT-x-algarve", EuropeanPortuguese, AlgarveDialect,
+                 region="Algarve"),
+    DialectEntry("pt-PT-x-madeira", EuropeanPortuguese, MadeiraDialect,
+                 region="Madeira"),
+    DialectEntry("pt-PT-x-azores", EuropeanPortuguese, AzoresDialect,
+                 region="Açores (São Miguel)", aliases=("pt-PT-x-acores",)),
+)
+
+DIALECT_REGISTRY: Dict[str, DialectEntry] = {e.code.lower(): e for e in _ENTRIES}
+_ALIAS_INDEX: Dict[str, DialectEntry] = {
+    alias.lower(): e for e in _ENTRIES for alias in e.aliases
+}
+
+
+def normalize_dialect_code(lang: str) -> str:
+    """Normalize the casing of a BCP-47 tag (``PT-pt-X-PORTO`` → ``pt-PT-x-porto``).
+
+    The language subtag is lowercased, two-letter region subtags are
+    uppercased, and everything else (including the ``x`` private-use marker
+    and its subtags) is lowercased. The tag structure is not validated.
+    """
+    segments = (lang or "").strip().split("-")
+    normalized = []
+    for i, seg in enumerate(segments):
+        if i > 0 and len(seg) == 2 and seg.lower() != "x":
+            normalized.append(seg.upper())
+        else:
+            normalized.append(seg.lower())
+    return "-".join(normalized)
+
+
+def resolve_dialect(lang: str = "pt-PT") -> DialectEntry:
+    """Resolve a language code to its :class:`DialectEntry`.
+
+    Resolution order: exact canonical code, then alias, both
+    case-insensitive. Unknown codes fall back by popping trailing subtags
+    (``pt-PT-x-unknown`` → ``pt-PT``); anything still unmatched resolves to
+    ``pt-PT``, preserving the European Portuguese default.
+    """
+    key = normalize_dialect_code(lang).lower()
+    while key:
+        entry = DIALECT_REGISTRY.get(key) or _ALIAS_INDEX.get(key)
+        if entry is not None:
+            return entry
+        if "-" not in key:
+            break
+        key = key.rsplit("-", 1)[0]
+    return DIALECT_REGISTRY["pt-pt"]
+
+
+def get_dialect_inventory(lang: str = "pt-PT") -> DialectInventory:
+    """Return a fresh :class:`DialectInventory` for ``lang``."""
+    return resolve_dialect(lang).inventory()
+
+
+def get_regional_transforms(lang: str = "pt-PT") -> Optional[RegionalTransforms]:
+    """Return the regional accent preset for ``lang``, or ``None``."""
+    return resolve_dialect(lang).transforms
+
+
+def list_dialects() -> List[str]:
+    """Return all canonical dialect codes, sorted. Aliases are not listed."""
+    return sorted(e.code for e in _ENTRIES)

--- a/tugaphone/registry.py
+++ b/tugaphone/registry.py
@@ -107,11 +107,16 @@ def normalize_dialect_code(lang: str) -> str:
     """
     segments = (lang or "").strip().split("-")
     normalized = []
+    in_private_use = False
     for i, seg in enumerate(segments):
-        if i > 0 and len(seg) == 2 and seg.lower() != "x":
+        low = seg.lower()
+        if low == "x":
+            in_private_use = True
+            normalized.append(low)
+        elif i > 0 and len(seg) == 2 and not in_private_use:
             normalized.append(seg.upper())
         else:
-            normalized.append(seg.lower())
+            normalized.append(low)
     return "-".join(normalized)
 
 


### PR DESCRIPTION
## What

A single dialect registry (`tugaphone/registry.py`) mapping BCP-47 codes to `DialectInventory` classes and `RegionalTransforms` presets, so every supported dialect is reachable by language code:

- 5 majors: `pt-PT`, `pt-BR`, `pt-AO`, `pt-MZ`, `pt-TL` (alias `pt`)
- 3 city inventories: `pt-PT-x-lisbon`, `pt-BR-x-rio-janeiro`, `pt-BR-x-sao-paulo` — previously defined but unreachable
- 12 regional presets: `pt-PT-x-porto`, `-north`, `-minho`, `-braga`, `-famalicao`, `-fafe`, `-transmontano`, `-coimbra`, `-alentejo`, `-algarve`, `-madeira`, `-azores` — previously manual-import only

`phonemize_sentence(s, "pt-PT-x-porto")` now applies the Porto preset directly; an explicit `regional_dialect=` kwarg still overrides. Resolution is case-insensitive with aliases (`pt-PT-x-lisboa`, `-acores`, `-tras-os-montes`, `-central`, `-norte`, `pt-BR-x-rio`) and falls back by popping subtags (`pt-PT-x-unknown` → `pt-PT`). The G2P plugin's `language_codes` now exposes all 20 codes.

Public API: `resolve_dialect`, `list_dialects`, `get_regional_transforms`, `normalize_dialect_code`, `DialectEntry` (first three re-exported from the package root).

## Tests

`tests/test_registry.py` (47 tests): resolution/aliases/fallbacks, preset identity, plugin exposure, and phonemizer integration — `pt-PT-x-porto` ≡ manual `PortoDialect`, kwarg override, São Paulo ≠ pt-BR divergence, and the 5 majors pinned to execution-captured output proving back-compat. Full suite: 255 passed.

## Docs

`docs/dialects.md` gains a "Dialect codes" section + Code column on the preset table; `docs/api.md` documents `tugaphone.registry`; new `examples/10_dialect_registry.py`; README quick-start updated. All IPA strings execution-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regional accent presets are now selectable via standardized BCP-47 dialect codes (e.g., `pt-PT-x-porto`, `pt-PT-x-azores`)
  * Added `list_dialects()` function to discover all available regional and city-level dialect options
  * Support for case-insensitive dialect code resolution with alias support and automatic fallback to European Portuguese for unknown codes

* **Documentation**
  * Updated README and API documentation to reflect new dialect selection approach
  * Added comprehensive dialect registry guide with dialect code conventions and usage examples
  * New example script demonstrating dialect registry functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->