### PR TITLE
fix: build_tests caller passes inputs the reusable workflow no longer defines

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -14,7 +14,6 @@ jobs:
   build_tests:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     with:
-      branch: dev
-      test_repo: false
-      test_location: "tests"
-      timeout: 15
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      install_extras: 'test'
+      test_path: 'tests'


### PR DESCRIPTION
Every `Run UnitTests` run ends in `startup_failure` because the caller passes `branch`/`test_repo`/`test_location`/`timeout`, none of which exist on `OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev` (current inputs: `python_versions`, `install_extras`, `pre_install_pip`, `test_path`, …). Updated to the same caller shape bifonia uses: py3.10–3.14 matrix, install with the `test` extra, run pytest against `tests/`.