### PR TITLE
refactor: rely on o2i 1.64 ẽĩũ orthographic vowels, drop private fallback

### DIFF
--- a/docs/tokenizer.md
+++ b/docs/tokenizer.md
@@ -28,10 +28,9 @@ library so tugaphone rides its substrate instead of forking it:
   vowel-letter membership — rather than maintaining tugaphone's own vowel and
   front-vowel character sets.
 
-**Known substrate gap:** `orthography2ipa.vowels.is_orthographic_vowel`
-recognises the precomposed nasal vowels `ã`/`õ` but not the archaic `ẽ`/`ĩ`/`ũ`,
-so `CharToken.is_vowel` keeps the dialect's precomposed nasal set as a fallback
-for archaic input until the shared set covers them.
+`orthography2ipa.vowels.is_orthographic_vowel` recognises the full precomposed
+nasal-vowel set, including the archaic `ẽ`/`ĩ`/`ũ`, so `CharToken.is_vowel`
+delegates to it with no local fallback.
 
 ## Building a Sentence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "tugatagger[brill]",
     "tugalex",
     "bifonia",
-    "orthography2ipa>=1.58.1a1",
+    "orthography2ipa>=1.64.0a1",
 ]
 
 [project.entry-points."orthography2ipa.syllabify"]

--- a/tugaphone/tokenizer.py
+++ b/tugaphone/tokenizer.py
@@ -408,15 +408,12 @@ class CharToken:
         With diacritics: á, à, â, ã, é, ê, í, ó, ô, õ, ú
         Archaic: è, ì, ò, ù, ẽ, ĩ, ũ, ä, ë, ï, ö, ü, ÿ
 
-        Base classification is delegated to the shared
+        Classification is fully delegated to the shared
         :func:`orthography2ipa.vowels.is_orthographic_vowel` (the single
-        owner of vowel-letter membership), with the dialect's precomposed
-        nasal-vowel set kept as a fallback: the shared set recognises ã/õ
-        but not the archaic ẽ/ĩ/ũ (orthography2ipa gap, see
-        ``docs/tokenizer.md``).
+        owner of vowel-letter membership), including the archaic ẽ/ĩ/ũ.
         """
         s = self.normalized
-        return is_orthographic_vowel(s) or s in self.dialect.TILDE_VOWEL_CHARS
+        return is_orthographic_vowel(s)
 
     @cached_property
     def is_semivowel(self) -> bool:


### PR DESCRIPTION
## Summary
- orthography2ipa 1.64.0a1 extends `is_orthographic_vowel` to cover the archaic nasal vowels ẽ/ĩ/ũ, closing the gap tugaphone previously worked around.
- Re-pin `orthography2ipa>=1.64.0a1` (prerelease floor) in pyproject.toml.
- `CharToken.is_vowel` now delegates fully to `orthography2ipa.vowels.is_orthographic_vowel`; the dialect's `TILDE_VOWEL_CHARS` fallback in that check is removed.
- `docs/tokenizer.md` updated to drop the now-resolved "known substrate gap" note.

## Follow-up (out of scope)
Routing IPA generation through `ipa_lattice` so tugaphone's rules become live rescorers is a larger separate refactor, noted for later.

## Test plan
- [x] `uv pip install orthography2ipa==1.64.0a1` then confirmed `is_orthographic_vowel` is True for ẽ/ĩ/ũ (was False at 1.58.1a1)
- [x] Full test suite: 275 passed, 1 skipped (pre-existing skip: gold IPA test set not present, unrelated to this change)
- [x] Behavior-preserving: diff is docstring + `or s in self.dialect.TILDE_VOWEL_CHARS` removal only, no test output changed