### PR TITLE
refactor: consume o2i 1.70 Portuguese phonology; scope sentence-seam adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,36 @@ p = TugaphoneG2PPlugin(lang="pt-BR")
 print(p.transcribe("o gato dorme"))   # ˈu gˈa·tʊ ˈdoɾ·mɪ
 ```
 
+### IPA is built word-by-word (no cross-word sandhi)
+
+tugaphone builds a sentence's IPA from a **character-level cascade**: each
+`CharToken.ipa` composes into a `GraphemeToken`, graphemes into a
+`WordToken.ipa`, and `Sentence.ipa` is those word IPAs joined with spaces —
+each word transcribed **independently**. tugaphone does *not* route generation
+through `orthography2ipa`'s pronunciation lattice (`G2P.ipa_lattice`) or its
+`G2P.transcribe`; it consumes only o2i's shared *primitives* (the
+`PhonetokTokenizer` grapheme trie, `vowels` classification, `StressRules`, and
+`LanguageSpec` loading) and applies its own dialect grapheme rules.
+
+A consequence is that genuinely cross-word phonology is not modelled on the
+generation path. Standard European Portuguese **external `/s`-sandhi** — a
+word-final coda `/s/` (isolated `[ʃ]`) voicing before a vowel-initial next word
+(*os amigos* → `[ˈuz ɐˈmiɡuʃ]`, Mateus & d'Andrade 2000) — is **not** applied
+in the base `pt-PT` output (`os` stays `[ˈuʃ]`). The southern/insular presets'
+`sibilant_voicing_sandhi` is a per-token approximation: it voices a token's own
+final `[ʃ]`→`[ʒ]` when the word ends in `<s>`, with no visibility of the
+following word.
+
+`orthography2ipa` (≥1.70) now carries this cross-word phonology natively — a
+declarative `sandhi_rules` set on the `pt-PT` spec (`PT_FINAL_S_PREVOCALIC_VOICE`
+→ `[z]`; `pt-PT-x-algarve`/`acores` → `[ʒ]`) run through its `SandhiEngine`, and
+a `SentenceRescorer` / `SentenceLattice` **sentence-context seam** for
+boundary-aware rewrites. tugaphone cannot consume either today because neither
+its per-word IPA nor its lattice flows through o2i's `G2P`. Adopting the seam is
+a scoped follow-up (a "B6 stage-2" refactor) that routes sentence-level
+generation through o2i so cross-word sandhi is modelled once, upstream, instead
+of re-approximated per token. See `docs/advanced.md`.
+
 ---
 
 ## Sibling libraries

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -123,6 +123,66 @@ usable on its own:
 A TTS front-end typically wires `tugaphone` as the G2P stage: normalize text,
 phonemize per target dialect, hand the IPA string to the acoustic model.
 
+## Cross-word phonology and the sentence-context seam
+
+`Sentence.ipa` joins each `WordToken.ipa` with spaces and transcribes every word
+**independently** — a character-level cascade (`CharToken` → `GraphemeToken` →
+`WordToken` → `Sentence`) that never crosses a word boundary. tugaphone consumes
+`orthography2ipa`'s shared *primitives* (grapheme trie, vowel classification,
+stress rules, `LanguageSpec`) but does **not** route IPA generation through
+o2i's `G2P.transcribe` or its pronunciation lattice (`G2P.ipa_lattice`).
+
+Because of that, cross-word processes are unmodelled on the generation path:
+
+- Standard EP **external `/s`-sandhi** (coda `/s/` `[ʃ]` → `[z]` before a
+  vowel-initial next word: *os amigos* → `[ˈuz ɐˈmiɡuʃ]`, Mateus & d'Andrade
+  2000) is **not** applied in base `pt-PT`; `os` stays `[ˈuʃ]`.
+- The southern/insular `sibilant_voicing_sandhi` IPA transform is a per-token
+  approximation: it voices a token's own final `[ʃ]` → `[ʒ]` whenever the word
+  ends in `<s>`, with no visibility of the following word — so it fires even
+  utterance-finally, where a true cross-word rule would not.
+
+`orthography2ipa` (≥1.70) now provides both a declarative `sandhi_rules` set on
+the Portuguese specs (`PT_FINAL_S_PREVOCALIC_VOICE` → `[z]`;
+`pt-PT-x-algarve` / `pt-PT-x-acores` → `[ʒ]`, run through its `SandhiEngine`) and
+a **sentence-context seam** (`orthography2ipa.sentence`: `G2P.sentence_lattice`,
+`SentenceRescorer`, `SentenceRescoreContext`) that exposes each word's phrase /
+utterance position and its neighbours' edge lattice slots for boundary-aware,
+bidirectional rewrites. tugaphone cannot consume either today: the seam operates
+over o2i's `SentenceLattice`, and tugaphone's per-word IPA is not produced by
+o2i's `G2P`.
+
+### B6 stage-2 — adopting the seam (follow-up)
+
+Routing generation through o2i's lattice is a **breaking** change to tugaphone's
+segment model and is deliberately out of scope for the o2i-1.70 re-pin. A
+concrete path:
+
+1. **Post-pass with `SandhiEngine` (smaller, string-level).** `Sentence.ipa`
+   already materialises `word_ipas = [word.ipa for word in self.words]`. Feed
+   that list to o2i's `SandhiEngine(spec.sandhi_rules).apply(word_ipas)` for the
+   resolved `LanguageSpec`. This buys `PT_FINAL_S_PREVOCALIC_VOICE` and the
+   algarve/açores `[ʒ]` variants cross-word-correctly. **Hazards to gate first:**
+   (a) o2i's `sandhi_rules` regexes are written against o2i's IPA conventions —
+   verify tugaphone's word IPA (syllable `·` separators, combining vs
+   precomposed nasal tildes, leading stress marks) matches the `left_context` /
+   `right_context` classes on a gold set before enabling; (b) **double
+   application** with the existing per-token `sibilant_voicing_sandhi` on the
+   southern/insular presets (o2i's açores spec re-declares the rule) — one path
+   must own the voicing, not both; (c) it is a behaviour change (base `pt-PT`
+   gains `[z]`) and needs the gold IPA test set migrated, not just parity.
+
+2. **Full seam consumption (larger, lattice-level).** To use `SentenceRescorer`
+   / `SentenceLattice` — and the phrase/utterance-position and edge-slot
+   visibility they carry — tugaphone must expose its per-word transcription as
+   o2i `SegmentSlot` lattices (or generate through o2i's `G2P` directly). This is
+   the segment-model refactor and carries the **atomic-vs-decomposed grapheme
+   hazard** barranquenho hit: tugaphone's `GraphemeToken` groups multi-char
+   graphemes (`nh`, `lh`, `ch`, nasal digraphs) whose IPA must map onto o2i's
+   per-grapheme slots without splitting a nasal vowel from its tilde or an
+   affricate from its parts. Sequence it after (1) proves the sandhi rules are
+   correct on the string path.
+
 ## Where next
 
 - [api.md](api.md) — full signatures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "tugatagger[brill]",
     "tugalex",
     "bifonia",
-    "orthography2ipa>=1.64.0a1",
+    "orthography2ipa>=1.70.2a1",
 ]
 
 [project.entry-points."orthography2ipa.syllabify"]


### PR DESCRIPTION
## What

Re-pin `orthography2ipa>=1.70.2a1` (prerelease floor) and document the
cross-word phonology gap + a concrete B6-stage-2 plan. **Behaviour-preserving:
no tugaphone rule is dropped and nothing is ported into o2i.**

## Why the re-pin is safe (and drops nothing)

tugaphone builds a sentence's IPA from an **independent character-level cascade**
(`CharToken` → `GraphemeToken` → `WordToken` → `Sentence.ipa`, each word
transcribed independently). It consumes only o2i's shared *primitives*
(`PhonetokTokenizer` grapheme trie, `vowels` classification, `StressRules`,
`LanguageSpec` loading) — **not** `G2P.transcribe`, `G2P.ipa_lattice`, the
`SandhiEngine`, or the new `SentenceRescorer`/`SentenceLattice` seam. So o2i's
Portuguese phonology (external `/s`-sandhi #238, EP accent specs #247, sentence
seam #248) lives entirely on a path tugaphone never invokes: it cannot reach,
and cannot double-apply against, tugaphone's output. Full suite stays green
(**275 passed, 1 skipped** — the skip is a pre-existing missing-gold-data gate,
not a dep skip) and the characterization set is byte-identical before/after.

## Char-cascade confirmed; sentence-seam verdict

`Sentence.ipa` = `" ".join(word.ipa ...)` with each word independent (the source
even comments that liaison/resyllabification are unmodelled). tugaphone does
**not** build from `ipa_lattice`/`sentence_lattice`. Consuming the
`SentenceRescorer` seam is therefore **not tractable in this pass** — see the
"B6 stage-2" section in `docs/advanced.md` (string-level `SandhiEngine`
post-pass first, full lattice/segment-model migration second, with the
double-application and atomic-vs-decomposed-grapheme hazards enumerated).

## Cross-word characterization (why the gap is real)

| input | tugaphone `pt-PT` | o2i `pt-PT` spec intent |
|---|---|---|
| os amigos | `ˈuʃ ɐ·ˈmiɡuʃ` | `os`→`[ˈuz]` (`PT_FINAL_S_PREVOCALIC_VOICE`, Mateus & d'Andrade 2000) |
| estás a ver | `ɨʃˈtaʃ ˈɐ ˈveɾ` | `estás`→`[…taz]` before vowel |

tugaphone's `sibilant_voicing_sandhi` (algarve/açores presets) fires per-token
whenever the word ends in `<s>`, with **no** next-word gating, so it also voices
utterance-finally where a true cross-word rule would not.

## Transform-validation checklist (for a separate research pass)

The user has confirmed tugaphone's regional transforms were **eyeballed, not
research-validated** — treat every row below as an *unverified hypothesis* until
checked against a cited source and against o2i's benchmarked spec output. None
were dropped here. "o2i counterpart" points a validator at where o2i models the
same phenomenon (in o2i's own g2p/spec path); it is **not** a claim of
equivalence.

### `ipa_transforms.py` (regional; only active with an accent preset)

- [ ] **retain_ou_diphthong** — <ou>→[ow] kept (northern). o2i: EP accent specs (porto/minho). Cross-word: no.
- [ ] **retain_ei_diphthong** — <ei>→[ej] kept (northern). o2i: EP accent specs. Cross-word: no.
- [ ] **monophthongize_ei** — [ej]→[e] (Alentejo). o2i: pt-PT-x-alentejo? verify. Cross-word: no.
- [ ] **betacism** — /v/→[b] (northern). o2i: porto/braga specs. Cross-word: no.
- [ ] **reduce_vowel_centralization** — resist centralisation (Minho). o2i: base reduction differs. Cross-word: no.
- [ ] **open_vowel_preference** — open /a/ (Minho). o2i: accent spec. Cross-word: no.
- [ ] **conservative_o_nasal_retention** — -ão→[õ] (Famalicão/Transmontano). o2i: verify. Cross-word: no.
- [ ] **nasal_vowel_raising** — raised nasals (Minho). o2i: verify. Cross-word: no.
- [ ] **palatal_affrication_ch** — <ch>→[tʃ] (Transmontano). o2i: verify accent spec. Cross-word: no.
- [ ] **rhotic_realization** — alveolar [r] (Minho). o2i: rhotic in spec. Cross-word: no.
- [ ] **epenthetic_j_before_palatal** — palatal epenthesis (Braga). o2i: verify. Cross-word: no.
- [ ] **rising_diphthong_o** — stressed /o/→[uo] (Porto). o2i: pt-PT-x-porto? verify. Cross-word: no.
- [ ] **intervocalic_s_voicing** — /s/→[z] intervocalic + final (Transmontano). o2i: base intervocalic handling; **word-final leg is quasi-cross-word** — flag. 
- [ ] **initial_z_devoicing** — word-initial /z/→[s] (Transmontano). o2i: verify. Cross-word: no.
- [ ] **final_nasal_denasalization** — -agem ʒẽ→ʒe (Transmontano). o2i: verify. Cross-word: no.
- [ ] **nasal_diphthongization_e** — /ẽ/→[eĩ] (Fafe). o2i: verify. Cross-word: no.
- [ ] **nasal_glide_palatalization** — final nasal glide→[ɲ] (Braga). o2i: verify. Cross-word: no.
- [ ] **intervocalic_d_deletion** — intervocalic /d/→∅ (Alentejo). o2i: verify. Cross-word: no.
- [ ] **simplify_nasal_diphthong_em** — -em [ɐ̃j̃]→[ẽ] (Alentejo). o2i: verify. Cross-word: no.
- [ ] **simplify_meu_class** — [ew]→[e] in meu/teu (Alentejo/Algarve). o2i: verify. Cross-word: no.
- [ ] **sibilant_voicing_sandhi** — token-final [ʃ]→[ʒ] when word ends `<s>` (Alentejo/Algarve/Açores). **CROSS-WORD process approximated per-token, no next-word gate.** o2i: `PT_FINAL_S_PREVOCALIC_VOICE` ([z]) / algarve+açores ([ʒ]) `sandhi_rules`. **Prime candidate for seam adoption after B6.**
- [ ] **lateral_palatalization** — /l/→[ʎ]/_i (Madeira/Açores). o2i: verify. Cross-word: no.
- [ ] **nasal_diphthong_to_nasal_plus_n** — Ṽj̃→Ṽ+[n] (Madeira/Açores). o2i: verify. Cross-word: no.
- [ ] **fronted_stressed_u** — stressed /u/→[y] (São Miguel). o2i: pt-PT-x-sao-miguel? verify. Cross-word: no.
- [ ] **monophthongize_oi** — [oj]→[o] (Açores). o2i: verify. Cross-word: no.

### `dialects.py` (base grapheme→IPA inventories, always active)

- [ ] Base **vowel reduction** (unstressed a→ɐ, o→u, e→ɨ; pt-BR variants) — o2i base pt-PT/pt-BR spec reduction; compare word-by-word.
- [ ] Base **coda /s/ → [ʃ]** (EP) / palatalisation before consonants — o2i base spec; compare.
- [ ] Base **nasalisation** (vowel + m/n → nasal vowel; ão/ãe/õe diphthongs) — o2i base spec + #231 ẽĩũ; compare.
- [ ] Per-dialect consonant inventories (pt-BR palatalisation ti/di→[tʃ]/[dʒ], AO/MZ/TL) — o2i pt-BR/pt-AO/pt-MZ/pt-TL specs; compare.

## Scope discipline

Nothing dropped; nothing ported into o2i; no phonological behaviour changed.
This PR is the mechanical re-pin + the honest architecture/seam assessment and
the validation backlog above. Adopting any o2i rule (or retiring a tugaphone
one) waits on the research-validation pass and, for cross-word rules, the B6
stage-2 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on sentence-level IPA generation and current cross-word phonology limitations.
  * Documented how sibilant voicing and `/s`-sandhi are handled, including planned improvements for sentence-context processing.
  * Added technical notes covering potential future approaches and compatibility considerations.

* **Maintenance**
  * Updated the minimum supported `orthography2ipa` version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->