### PR TITLE
fix: correct accent-transform primitives to cited forms (keep framework)

### DIFF
--- a/tests/test_dialect_quality.py
+++ b/tests/test_dialect_quality.py
@@ -105,9 +105,10 @@ class TestRegionalPresetsSignatureFeatures:
         assert "tʃ" in out, f"Expected tʃ in {out!r}"
 
     def test_porto_rising_diphthong_o(self, pho):
-        """Porto: tonic [ˈo] → [ˈuo] rising diphthong — 'porto' [pˈuoɾtu]."""
+        """Porto: tonic close [ˈo] → [ˈwo] rising diphthong — 'porto' [pˈwoɾtu]
+        (Cintra 1971:684 "[o] em [wo]"; o2i PT_PORTO_DIPHTHONGISE_O)."""
         out = PortoDialect.apply_ipa("porto", "pˈoɾtu")
-        assert "uo" in out, f"Expected 'uo' in {out!r}"
+        assert "wo" in out, f"Expected 'wo' in {out!r}"
 
     def test_fafe_nasal_diphthongization_e(self, pho):
         """Fafe: /ẽ/ before consonant → [eĩ] — 'gente' [ˈʒẽtɨ] → [ˈʒeĩtɨ]."""

--- a/tests/test_regional.py
+++ b/tests/test_regional.py
@@ -59,9 +59,9 @@ class TestFromDict:
 
 class TestApplyIpa:
     def test_porto_applies_rules_in_order(self):
-        # rising_diphthong_o turns tonic ˈo into ˈuo
+        # rising_diphthong_o turns tonic close ˈo into ˈwo (Cintra 1971:684)
         out = PortoDialect.apply_ipa("porto", "pˈoɾtu")
-        assert "ˈuo" in out
+        assert "ˈwo" in out
 
     @pytest.mark.parametrize("preset", ALL_PRESETS)
     def test_all_preset_rules_are_registered(self, preset):

--- a/tests/test_regional_grounded.py
+++ b/tests/test_regional_grounded.py
@@ -113,9 +113,16 @@ class TestIpaRulePhenomena:
         assert "j" not in out
         assert "mˈe" in out
 
-    def test_betacism_merges_v_and_beta(self):
+    def test_betacism_merges_v_to_stop_in_strong_position(self):
+        # word-initial /v/ merges to the stop [b] (Cintra 1971:87 "b ou β")
         assert betacism("vaca", "ˈvakɐ") == "ˈbakɐ"
-        assert betacism("neve", "ˈnɛβɨ") == "ˈnɛbɨ"
+
+    def test_betacism_keeps_intervocalic_spirant(self):
+        # Cintra 1971:87: the merged labial is "ora oclusiva, ora fricativa
+        # (b ou β)"; intervocalic /v/ merges to the spirant [β], not the stop,
+        # and an existing intervocalic [β] is kept (not folded to [b]).
+        assert betacism("neve", "ˈnɛvɨ") == "ˈnɛβɨ"
+        assert betacism("neve", "ˈnɛβɨ") == "ˈnɛβɨ"
 
     def test_reduce_vowel_centralization(self):
         # ɨ only between consonants on both sides
@@ -152,13 +159,32 @@ class TestIpaRulePhenomena:
         assert "j" in epenthetic_j_before_palatal("velho", "ˈvɛʎu")
 
     def test_rising_diphthong_o(self):
-        assert "ˈuo" in rising_diphthong_o("porto", "pˈoɾtu")
+        # Cintra 1971:684 "[o] em [wo]"; on-glide is [w] (o2i PT_PORTO_DIPHTHONGISE_O)
+        assert "ˈwo" in rising_diphthong_o("porto", "pˈoɾtu")
 
-    def test_intervocalic_s_voicing(self):
-        assert intervocalic_s_voicing("moço", "ˈmosu") == "ˈmozu"
+    def test_rising_diphthong_e(self):
+        # Cintra 1971:684 "[e] em [je]" — companion front-vowel diphthongisation
+        from tugaphone.ipa_transforms import rising_diphthong_e
+        assert "ˈje" in rising_diphthong_e("mês", "mˈeʃ")
+
+    def test_intervocalic_s_voicing_leaves_laminal_c_cedilha(self):
+        # Cintra trait 2 is a PLACE contrast, not voicing; ⟨ç⟩ is laminal /s/
+        # and is NOT voiced (moço stays [ˈmosu], not the old wrong [ˈmozu]).
+        assert intervocalic_s_voicing("moço", "ˈmosu") == "ˈmosu"
+
+    def test_intervocalic_s_voicing_apicalises_orthographic_s(self):
+        # ⟨ss⟩ → apico-alveolar [s̺]; intervocalic single ⟨s⟩ → voiced [z̺]
+        # (Cintra 1971:93: passo [ˈpas̺u], casa [ˈkaz̺ɐ]).
+        assert intervocalic_s_voicing("passo", "ˈpasu") == "ˈpas̺u"
+        assert intervocalic_s_voicing("casa", "ˈkazɐ") == "ˈkaz̺ɐ"
+
+    def test_intervocalic_s_voicing_leaves_laminal_z(self):
+        # ⟨z⟩ is laminal [z] and stays distinct (cozer [kuˈzeɾ], not apicalised)
+        assert intervocalic_s_voicing("cozer", "kuˈzeɾ") == "kuˈzeɾ"
 
     def test_initial_z_devoicing(self):
-        # word-initial /z/ before a vowel devoices to [s]
+        # word-initial /z/ before a vowel devoices to [s] — the GALICIAN trait 6
+        # (Cintra 1971:451-457), retained as a Galician-contact reading only
         assert initial_z_devoicing("zero", "zɛɾu").startswith("s")
 
     def test_final_nasal_denasalization(self):
@@ -185,20 +211,35 @@ class TestIpaRulePhenomena:
         # only words ending in <eu>/<eus> are touched
         assert simplify_meu_class("europa", "ewˈɾɔpɐ") == "ewˈɾɔpɐ"
 
-    def test_sibilant_voicing_sandhi(self):
-        assert sibilant_voicing_sandhi("amigos", "ɐˈmiɡuʃ") == "ɐˈmiɡuʒ"
+    def test_sibilant_voicing_sandhi_across_word_boundary(self):
+        # true EXTERNAL sandhi: coda [ʃ] voices before a following vowel-initial
+        # word (PWL "muitoj amigos"); the seam must be present in the span.
+        assert sibilant_voicing_sandhi("mas amigos", "maʃ ɐˈmiɡuʃ") == "maʒ ɐˈmiɡuʃ"
 
-    def test_sibilant_voicing_sandhi_requires_final_s_spelling(self):
-        assert sibilant_voicing_sandhi("paz", "ˈpaʃ") == "ˈpaʃ"
+    def test_sibilant_voicing_sandhi_isolated_token_unchanged(self):
+        # a single token in isolation is NOT voiced word-internally: the old
+        # rule wrongly yielded [ɐˈmiɡuʒ] / [meʒ] for words said alone.
+        assert sibilant_voicing_sandhi("amigos", "ɐˈmiɡuʃ") == "ɐˈmiɡuʃ"
+        assert sibilant_voicing_sandhi("meus", "meʃ") == "meʃ"
 
     def test_lateral_palatalization(self):
         assert lateral_palatalization("quilo", "ˈkilu") == "ˈkiʎu"
+
+    def test_lateral_palatalization_skips_coda_l(self):
+        # dropped the word-final branch: a coda /l/ (dark [ɫ]) is never
+        # palatalised; requires a FOLLOWING vowel (o2i MAD_L_PALATALISATION).
+        assert lateral_palatalization("mil", "ˈmiɫ") == "ˈmiɫ"
 
     def test_nasal_diphthong_to_nasal_plus_n(self):
         assert nasal_diphthong_to_nasal_plus_n("cães", "kɐ̃j̃ʃ") == "kɐ̃ns"
 
     def test_fronted_stressed_u(self):
         assert fronted_stressed_u("tu", "tˈu") == "tˈy"
+
+    def test_fronted_stressed_u_blocked_before_coda_liquid(self):
+        # fronting is blocked before a tautosyllabic coda liquid/sibilant
+        # (o2i ACO_U_KEEP_BEFORE_CODA): azul stays [ɐˈzuɫ], not [ɐˈzyɫ].
+        assert fronted_stressed_u("azul", "ɐˈzuɫ") == "ɐˈzuɫ"
 
     def test_monophthongize_oi(self):
         assert monophthongize_oi("boi", "boj") == "bo"
@@ -292,7 +333,7 @@ class TestPresetSignatureFeatures:
         assert "v" not in NorthernDialect.apply_ipa("vaca", "ˈvakɐ")
 
     def test_porto_rising_o(self):
-        assert "uo" in PortoDialect.apply_ipa("porto", "pˈoɾtu")
+        assert "wo" in PortoDialect.apply_ipa("porto", "pˈoɾtu")
 
     def test_minho_centralization_resisted(self):
         assert MinhoDialect.apply_ipa("bete", "bɨtɨ").startswith("be")

--- a/tugaphone/ipa_transforms.py
+++ b/tugaphone/ipa_transforms.py
@@ -23,6 +23,13 @@ de-biasing approach of Cintra's conservative-standard reference point.
 
 Transforms operate on grapheme clusters, not Python characters, so combining
 diacritics (nasal tilde U+0303, tie bars) stay attached to their base symbol.
+
+Note on ``postag``: every transform accepts ``postag`` for a uniform callable
+signature, but NO transform body reads it — none of these accent primitives is
+POS-conditioned. Genuine EP stress/vowel-quality homographs (e.g. *acordo*
+NOUN [ɐˈkoɾdu] / VERB [ɐˈkɔɾdu]) are handled by the separate ``dialects.py``
+IRREGULAR table (the base-G2P homograph layer), not here. ``postag`` is kept
+only so callers can pass it through uniformly.
 """
 
 import re
@@ -57,6 +64,8 @@ _ORAL_VOWELS = "aeiouɐɛɔɨyæøœɘ"
 _NASAL_VOWELS = "ãẽĩõũ"  # NFC-composed nasal vowels
 _VOWELS = _ORAL_VOWELS + _NASAL_VOWELS + "ɐ̃ɛ̃ɔ̃"
 _CONSONANTS = "pbtdkɡgfvszʃʒmnɲɫlrʁɾβð"
+# Orthographic (grapheme) vowels, for rules that condition on spelling.
+_ORTHO_VOWELS = "aeiouáéíóúàâêôãõ"
 
 
 # ---------------------------------------------------------------------------
@@ -122,22 +131,32 @@ def monophthongize_ei(word: str, phonemes: str, postag: str = "NOUN") -> str:
 # ---------------------------------------------------------------------------
 
 def betacism(word: str, phonemes: str, postag: str = "NOUN") -> str:
-    """Merge /v/ into the labial stop /b/ (betacism).
+    """Merge /v/ into the single labial phoneme /b/ (betacism).
 
     Phenomenon: in the northern third of Portugal the /v/–/b/ contrast is lost;
-    both are realised as the bilabial stop [b] (*vaca* [ˈbakɐ], *vinho* [ˈbiɲu],
-    *neve* [ˈnɛbɨ]). Any spirantised allophone [β] from the base G2P is folded
-    into [b] as well, so the rule is categorical and position-independent.
+    both fall together in one labial phoneme. Cintra (BF 22:87) is explicit that
+    the merged phoneme "é realizado ora como oclusiva, ora como fricativa (ou
+    espirante): b ou β" — i.e. it surfaces as the stop [b] in strong position
+    (word-initial, post-consonant: *vaca* [ˈbakɐ], *vinho* [ˈbiɲu]) and as the
+    spirant [β] intervocalically (*neve* [ˈnɛβɨ], *uva* [ˈuβɐ]), exactly the
+    positional [b]~[β] allophony EP already applies to underlying /b/. The
+    merger is categorical; the *realisation* is positionally conditioned, so an
+    existing intervocalic spirant [β] is kept, not folded to a stop.
 
     Distribution: all northern varieties — Minhoto, Transmontano, Duriense,
-    Beirão — plus Galician (Cintra 1971, the single most-cited northern
-    isogloss; whitepaper4 rule N1, whitepaper5 rule N1/DB4).
+    Beirão — plus Galician (Cintra 1971:87, the single most-cited northern
+    isogloss; whitepaper4 rule N1, whitepaper5 rule N1/DB4). o2i models the same
+    two realisations (allophones ``v: [b, β]`` in the porto/trásosmontes specs).
 
-    This realisation as a stop [b] follows Cintra and the project gold
-    transcriptions; an earlier draft modelling it as the approximant [β]
-    conflicts with both and is dropped.
+    ``postag`` is accepted for a uniform transform signature but unused here;
+    betacism is not POS-conditioned (homograph handling lives in the separate
+    ``dialects.py`` IRREGULAR table).
+
+    Source: Cintra (1971), *Boletim de Filologia* 22:87 ("b ou β").
     """
-    return phonemes.replace("v", "b").replace("β", "b")
+    # /v/ between vowels merges to the spirant realisation [β]; elsewhere to [b].
+    phonemes = re.sub(rf"(?<=[{_VOWELS}])v(?=[{_VOWELS}])", "β", phonemes)
+    return phonemes.replace("v", "b")
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +174,11 @@ def reduce_vowel_centralization(word: str, phonemes: str, postag: str = "NOUN") 
     to the Portuguese north by analogy with Galician less-reduction). The gold
     northern transcriptions keep [ɨ] in most tokens, so this rule is excluded
     from the categorical northern preset and offered only for the maximal
-    Minhoto reading.
+    Minhoto reading. ``postag`` unused (see module note).
+
+    PARTIALLY-VERIFIED — the direction (less northern atonic reduction) is
+    Cintra's trait 7, but the exact [ɨ]→[e] target mapping is not pinned to a
+    source. Use with caution.
     """
     return re.sub(
         rf"(?<=[{_CONSONANTS}])ɨ(?=[{_CONSONANTS}])", "e", phonemes
@@ -168,9 +191,12 @@ def open_vowel_preference(word: str, phonemes: str, postag: str = "NOUN") -> str
     Phenomenon: northern speakers favour a more open [a] for /ɐ/ in final,
     unstressed syllables before /m, n, ɲ, l/.
 
-    Distribution: northern, variable (Cintra 1971; DIALECT_PATTERNS "more open
-    vowels"). Conditioned narrowly to avoid over-application; the broad
-    de-centralisation of stressed /a/ is left to the base inventory.
+    Distribution: northern, variable (DIALECT_PATTERNS "more open vowels").
+    Conditioned narrowly to avoid over-application. ``postag`` unused.
+
+    UNVERIFIED — the general "more open a" direction is Cintra's trait 7, but
+    that concerns the TONIC /a/; the specific conditioning here (final-atonic
+    /ɐ/ before a nasal/lateral) is not attested in a source. Use with caution.
     """
     return re.sub(r"ɐ(?=[mnɲl]\b)", "a", phonemes)
 
@@ -182,9 +208,14 @@ def conservative_o_nasal_retention(word: str, phonemes: str, postag: str = "NOUN
     the standard has merged it into the nasal diphthong [ɐ̃w̃] (*pão* [põ],
     *irmão* [iɾˈmõ]).
 
-    Distribution: Trás-os-Montes / Alto-Minho (Cintra 1971; whitepaper5 rule
-    TM3). The matched ending is sliced by grapheme cluster, so the combining
-    nasal tilde never desynchronises from its base vowel.
+    Distribution: Trás-os-Montes / Alto-Minho (whitepaper5 rule TM3). The
+    matched ending is sliced by grapheme cluster, so the combining nasal tilde
+    never desynchronises from its base vowel. ``postag`` unused.
+
+    PARTIALLY-VERIFIED — the archaic interior -ão→[õ] outcome is real
+    dialectology (Trás-os-Montes/Alto-Minho), but no explicit Cintra page was
+    located for the [õ] realisation; corroborate against Segura (2013)/ALEPG
+    before trusting. Plausible.
     """
     if not word.endswith("ão"):
         return phonemes
@@ -209,8 +240,11 @@ def nasal_vowel_raising(word: str, phonemes: str, postag: str = "NOUN") -> str:
     Phenomenon: northern nasal vowels are slightly raised/fronted relative to
     the standard; /ɐ̃/ tends toward [ã] (*mãe* [mˈãj̃]).
 
-    Distribution: northern (Cintra 1971; DIALECT_PATTERNS). Operates on the
-    grapheme cluster ``ɐ̃`` so the tilde is preserved.
+    Distribution: northern (DIALECT_PATTERNS). Operates on the grapheme cluster
+    ``ɐ̃`` so the tilde is preserved. ``postag`` unused (see module note).
+
+    UNVERIFIED — not corroborated by an academic source; rests only on the
+    repo's own DIALECT_PATTERNS field notes. Use with caution.
     """
     return phonemes.replace("ɐ̃", "ã")
 
@@ -260,24 +294,54 @@ def epenthetic_j_before_palatal(word: str, phonemes: str, postag: str = "NOUN") 
     palatal /ʎ, ɲ, ʃ/: *velho* [ˈvɛjʎu], *abelha* [aˈbejʎɐ], *bolacha*
     [buˈlajʃɐ], *banha* [ˈbajɲɐ].
 
-    Distribution: Minho and adjacent northwest (Cintra 1971; DIALECT_PATTERNS).
-    Fires on stressed and unstressed [a ɐ e ɛ]; ``(?!j)`` prevents a double
-    glide. Rule: V → Vj / __[ʎ ɲ ʃ].
+    Distribution: Minho and adjacent northwest (DIALECT_PATTERNS). Fires on
+    stressed and unstressed [a ɐ e ɛ]; ``(?!j)`` prevents a double glide. Rule:
+    V → Vj / __[ʎ ɲ ʃ]. ``postag`` unused (see module note).
+
+    UNVERIFIED — the yod before a palatal ([ɐj]ʎ, *telha*) also occurs in
+    STANDARD EP (Mateus & d'Andrade 2000), so the Minho-only attribution is
+    doubtful and no source pins it as a distinctive Minho feature. Use with
+    caution.
     """
     return re.sub(r"(ˈ?[aɐeɛ])(?=[ʎɲʃ])(?!j)", r"\1j", phonemes)
 
 
 def rising_diphthong_o(word: str, phonemes: str, postag: str = "NOUN") -> str:
-    """Diphthongise stressed /o/ to the rising diphthong [wo].
+    """Diphthongise stressed close /o/ to the rising diphthong [wo].
 
-    Phenomenon: the Porto / Baixo-Minhoto area diphthongises stressed mid
-    vowels (*Porto* [ˈpwoɾtu], *bolo* [ˈbwolu]); the transcription [uo] is used
-    here for the rising on-glide.
+    Phenomenon: the Porto / Baixo-Minho / Douro-Litoral area diphthongises the
+    tonic close mid vowels. Cintra (1971:684) names it "a ditongação, tão
+    caracterizadora, das vogais tónicas fechadas [e] em [je], [o] em [wo] (por
+    vezes [wɔ])" — the single defining Porto marker. The back-vowel half is
+    *Porto* [ˈpwoɾtu], *bolo* [ˈbwolu], *avô* [ɐˈbwo]. The on-glide is [w], so
+    the diphthong is [wo] (matching o2i ``PT_PORTO_DIPHTHONGISE_O``); the front
+    counterpart /e/→[je] is :func:`rising_diphthong_e`.
 
-    Distribution: Porto variety / Douro Litoral, shared with an Astur-Leonese
-    archaic stratum (Cintra 1971; whitepaper5 rule PT2, whitepaper4 §3.3).
+    Distribution: Porto variety / Baixo-Minho / Douro-Litoral (Cintra 1971:684;
+    whitepaper5 rule PT2, whitepaper4 §3.3). ``postag`` unused (see module note).
+
+    Source: Cintra (1971:684), *Boletim de Filologia* 22 ("[o] em [wo]").
     """
-    return re.sub(r"ˈo(?![wj])", "ˈuo", phonemes)
+    return re.sub(r"ˈo(?![wj])", "ˈwo", phonemes)
+
+
+def rising_diphthong_e(word: str, phonemes: str, postag: str = "NOUN") -> str:
+    """Diphthongise stressed close /e/ to the rising diphthong [je].
+
+    Phenomenon: the front-vowel half of the defining Porto tonic-vowel
+    diphthongisation — Cintra's "[e] em [je]" (*mês* [ˈmjeʃ], *ele* [ˈjelɨ],
+    *pêlo* [ˈpjelu]). Companion to :func:`rising_diphthong_o` ("[o] em [wo]");
+    the two together are Cintra's "ditongação, tão caracterizadora, das vogais
+    tónicas fechadas". Fires on the close [e] the base G2P yields; genuinely
+    open tonic [ɛ] (*pé*, *café*) does not diphthongise, matching o2i
+    ``PT_PORTO_DIPHTHONGISE_E``.
+
+    Distribution: Porto variety / Baixo-Minho / Douro-Litoral (Cintra 1971:684).
+    ``postag`` unused (see module note).
+
+    Source: Cintra (1971:684), *Boletim de Filologia* 22 ("[e] em [je]").
+    """
+    return re.sub(r"ˈe(?![wji])", "ˈje", phonemes)
 
 
 # ---------------------------------------------------------------------------
@@ -285,26 +349,64 @@ def rising_diphthong_o(word: str, phonemes: str, postag: str = "NOUN") -> str:
 # ---------------------------------------------------------------------------
 
 def intervocalic_s_voicing(word: str, phonemes: str, postag: str = "NOUN") -> str:
-    """Voice /s/ to [z] between vowels and word-finally after a vowel.
+    """Mark the northeast four-sibilant contrast: apico-alveolar ⟨s,ss⟩.
 
-    Phenomenon: a lenition pattern in Transmontano voicing intervocalic and
-    final post-vocalic /s/ (*moço* [ˈmozu]).
+    Re-scoped correction. Cintra's trait 2 (his single most diagnostic
+    North/South isogloss, 1971:93) is NOT a voicing of /s/ — it is a PLACE
+    contrast: Transmontano/Alto-Minhoto keep a medieval four-sibilant system in
+    which the graphemes ⟨s⟩ (initial, final) and ⟨ss⟩ (interior) realise the
+    apico-alveolar [s̺] (with its voiced intervocalic-⟨s⟩ counterpart [z̺]),
+    contrasting with the laminal (predorsodental) [s] of ⟨c,ç⟩ and [z] of ⟨z⟩.
+    The minimal pairs stay distinct: *passo* [ˈpas̺u] vs *paço* [ˈpasu], *coser*
+    [kuˈz̺eɾ] vs *cozer* [kuˈzeɾ]. The earlier rule voiced ⟨ç⟩ (*moço*→[ˈmozu]),
+    which no source describes — ⟨ç⟩ is laminal /s/ and is now left untouched.
 
-    Distribution: Transmontano and adjacent northeast (Cintra 1971;
-    DIALECT_PATTERNS).
+    Only orthographically unambiguous positions are marked (a phoneme-level,
+    orthography-blind engine cannot fully reconstruct the source grapheme; the
+    complete four-sibilant model is the o2i pt-PT-x-trasosmontes spec). ⟨s⟩/⟨ss⟩
+    apical realisations are surface-equivalent to the retroflex-like [ʂ ʐ] Cintra
+    calls "s beirão / reverso"; the [s̺ z̺] symbols follow o2i.
+
+    Distribution: Transmontano and Alto-Minhoto (Cintra 1971:93 note 29;
+    Álvarez Pérez 2014:37 §4). ``postag`` unused (see module note).
+
+    Source: Cintra (1971:93) — "um sistema de quatro sibilantes… [s̺] e [z̺]
+    ápico-alveolares (grafemas s e ss)… opondo-se a… [s] e [z] predorsodentais
+    (grafemas c e,i, ç e z)".
     """
-    phonemes = re.sub(rf"(?<=[{_VOWELS}])s(?=[{_VOWELS}])", "z", phonemes)
-    phonemes = re.sub(rf"(?<=[{_VOWELS}])s(?=$)", "z", phonemes)
+    low = word.lower()
+    # word-initial ⟨s⟩ + vowel → apico-alveolar [s̺]
+    if re.match(rf"s[{_ORTHO_VOWELS}]", low):
+        phonemes = re.sub(r"^(ˈ?)s", r"\1s̺", phonemes)
+    # interior ⟨ss⟩ → apico-alveolar [s̺]; unambiguous only without a laminal
+    # ⟨ç/ce/ci⟩ in the same token that would also yield an intervocalic [s].
+    if "ss" in low and "ç" not in low and not re.search(r"c[eiéí]", low):
+        phonemes = re.sub(rf"(?<=[{_VOWELS}])s(?=[{_VOWELS}])", "s̺", phonemes)
+    # intervocalic single ⟨s⟩ (base G2P voices it to [z]) → apico-alveolar [z̺];
+    # unambiguous only when no ⟨z⟩ grapheme could account for the [z].
+    if re.search(rf"[{_ORTHO_VOWELS}]s[{_ORTHO_VOWELS}]", low) and "ss" not in low and "z" not in low:
+        phonemes = re.sub(rf"(?<=[{_VOWELS}])z(?=[{_VOWELS}])", "z̺", phonemes)
     return phonemes
 
 
 def initial_z_devoicing(word: str, phonemes: str, postag: str = "NOUN") -> str:
-    """Devoice word-initial /z/ to [s] before a vowel.
+    """Devoice word-initial /z/ to [s] before a vowel — a GALICIAN trait.
 
-    Phenomenon: part of the Transmontano four-sibilant reorganisation; initial
-    /z/ may surface as [s] (*zero* [ˈseɾu]).
+    Re-attributed correction. This is Cintra's trait 6, the *Galician* loss of
+    the voiced/voiceless sibilant opposition through devoicing ("de /z/ a /s/",
+    1971:451–457), NOT a Portuguese Transmontano feature. Conservative NE
+    Portuguese (Transmontano/Alto-Minhoto) does the OPPOSITE: it keeps the
+    voiced apico-alveolar [z̺] (see :func:`intervocalic_s_voicing` and the o2i
+    pt-PT-x-trasosmontes spec). This primitive is therefore removed from the
+    Transmontano preset and is offered only as a Galician-contact reading.
 
-    Distribution: Transmontano (Cintra 1971; DIALECT_PATTERNS).
+    Phenomenon (Galician): word-initial /z/ surfaces as [s] (*zero* [ˈseɾu]).
+
+    Distribution: Galician and the Galician-Portuguese contact fringe (Cintra
+    1971:451–457, trait 6). Do NOT compose into a Transmontano accent.
+    ``postag`` unused (see module note).
+
+    Source: Cintra (1971:451–457), *Boletim de Filologia* 22, trait 6.
     """
     return re.sub(rf"^z(?=[{_VOWELS}])", "s", phonemes)
 
@@ -315,8 +417,11 @@ def final_nasal_denasalization(word: str, phonemes: str, postag: str = "NOUN") -
     Phenomenon: Transmontano tends to denasalise unstressed final nasal vowels
     after /ʒ/ (*viagem* [viˈaʒe], *paragem* [pɐˈɾaʒe]).
 
-    Distribution: Transmontano (Cintra 1971; DIALECT_PATTERNS). Matched by
-    grapheme cluster so the nasal tilde is consumed with its base vowel.
+    Distribution: Transmontano (DIALECT_PATTERNS). Matched by grapheme cluster
+    so the nasal tilde is consumed with its base vowel. ``postag`` unused.
+
+    UNVERIFIED — not corroborated by an academic source; rests only on the
+    repo's own DIALECT_PATTERNS field notes. Use with caution.
     """
     phonemes = re.sub(r"ʒẽ$", "ʒe", phonemes)
     phonemes = re.sub(r"ʒɐ̃$", "ʒɐ", phonemes)
@@ -333,7 +438,10 @@ def nasal_diphthongization_e(word: str, phonemes: str, postag: str = "NOUN") -> 
     Distribution: Fafe / inner Minho (DIALECT_PATTERNS; the user's field notes).
     The negative lookahead keeps /ẽ/ before a vowel intact. The nasal /ẽ/ is
     matched whether the G2P emits it NFC-composed (U+1EBD) or NFD-decomposed
-    (e + combining tilde U+0303); output uses the NFC form.
+    (e + combining tilde U+0303); output uses the NFC form. ``postag`` unused.
+
+    UNVERIFIED — a single Fafe field note ("a geinte"); no academic source
+    locates this realisation. Use with caution.
     """
     e_nasal = r"(?:ẽ|ẽ)"
     follow = r"(?![aeiouɐɛɔɲʎ]|ẽ|ẽ|̃)"
@@ -349,7 +457,11 @@ def nasal_glide_palatalization(word: str, phonemes: str, postag: str = "NOUN") -
 
     Distribution: Braga area / northwest (DIALECT_PATTERNS). Rule:
     Ṽj̃ → Ṽɲ / _#. Operates on grapheme clusters so the nasalised glide is
-    matched as a unit.
+    matched as a unit. ``postag`` unused (see module note).
+
+    UNVERIFIED — northern reinforcement of final -em is reported
+    impressionistically (Braga field note) but not pinned to an academic
+    source. Use with caution.
     """
     nasal_vowels = "ãẽĩõũ" + "ɐ̃ɛ̃ɔ̃"
     phonemes = re.sub(rf"([{nasal_vowels}])[jw]̃$", r"\1ɲ", phonemes)
@@ -409,19 +521,26 @@ def simplify_meu_class(word: str, phonemes: str, postag: str = "NOUN") -> str:
 
 
 def sibilant_voicing_sandhi(word: str, phonemes: str, postag: str = "NOUN") -> str:
-    """Voice a word-final /s/-derived [ʃ] before a following vowel to [ʒ].
+    """Voice a coda [ʃ] to [ʒ] across a word boundary before a vowel-initial word.
 
-    Phenomenon: across a word boundary, the coda sibilant voices before a
-    vowel-initial word (*mas a* [maʒ ɐ], *muitos amigos* [ˈmũj̃tuʒ ɐˈmiɡuʒ]).
-    Applied within a token to its final [ʃ] when the orthography ends in <s>.
+    Corrected mechanism. This is genuinely EXTERNAL sandhi — the coda sibilant
+    voices only before a following vowel-initial word (*mas a* [maʒ ɐ], *muitos
+    amigos* [ˈmũj̃tuʒ ɐˈmiɡuʃ], PWL "tá-**j** a ver", "muito**j** amigos"). The
+    earlier rule applied it word-INTERNALLY to any token whose spelling ends in
+    ⟨s⟩, wrongly yielding [meʒ] for *meus* said in isolation. It is now gated on
+    a real cross-word seam: it fires only when ``word``/``phonemes`` hold a
+    multi-word span and the [ʃ] is immediately followed by a space and a
+    vowel-initial word. A single token in isolation is left unchanged (the true
+    seam handling belongs to the o2i sentence-level ``sandhi_rules``).
 
-    Distribution: general EP sandhi, marked here for the southern/insular
-    presets where the gold transcribes it word-internally on plurals (Cintra
-    1971; DIALECT_PATTERNS).
+    Distribution: general EP external sandhi, strongest in the south/insular
+    presets (Algarve/São Miguel; Cintra 1971; DIALECT_PATTERNS). ``postag``
+    unused (see module note).
+
+    Source: EP external voicing sandhi (Mateus & d'Andrade 2000); native PWL
+    transcripts (pwl-8-accents.md).
     """
-    if word.lower().rstrip(".").endswith("s"):
-        return re.sub(r"ʃ$", "ʒ", phonemes)
-    return phonemes
+    return re.sub(rf"ʃ(?=\s+ˈ?[{_VOWELS}])", "ʒ", phonemes)
 
 
 # ---------------------------------------------------------------------------
@@ -434,11 +553,16 @@ def lateral_palatalization(word: str, phonemes: str, postag: str = "NOUN") -> st
     Phenomenon: Madeira and the Azores palatalise /l/ adjacent to a high front
     vowel in specific items (*quilo* → [ˈkiʎu], *mochila* → [muˈʃiʎɐ]).
 
-    Distribution: Madeira and Azores (ALEPG / Segura & Saramago; DIALECT_PATTERNS).
-    Conditioned on a preceding [i] to model the lexically restricted set the
-    field notes describe.
+    Distribution: Madeira and Azores (Segura 2013; ALEPG; DIALECT_PATTERNS).
+    Conditioned on a preceding [i] AND a FOLLOWING vowel — matching o2i
+    ``MAD_L_PALATALISATION``, which requires an onset /l/ (a following vowel).
+    The earlier ``$`` (word-final) branch is dropped: it wrongly palatalised a
+    coda /l/ (*mil*→[miʎ]); a coda /l/ is realised dark [ɫ] and is never
+    palatalised. ``postag`` unused (see module note).
+
+    Source: Segura (2013); o2i MAD_L_PALATALISATION.
     """
-    return re.sub(r"(?<=i)l(?=u|ɐ|ɨ|$)", "ʎ", phonemes)
+    return re.sub(rf"(?<=i)l(?=[{_VOWELS}])", "ʎ", phonemes)
 
 
 def nasal_diphthong_to_nasal_plus_n(word: str, phonemes: str, postag: str = "NOUN") -> str:
@@ -463,10 +587,19 @@ def fronted_stressed_u(word: str, phonemes: str, postag: str = "NOUN") -> str:
     French-*tu*-like (*tu* [ty], *número* [ˈnymɨɾu]).
 
     Distribution: Açores, São Miguel (ALEPG / Segura & Saramago;
-    DIALECT_PATTERNS). Also documented for Beira-Baixa/Alto-Alentejo
-    (whitepaper5 rule BB1).
+    DIALECT_PATTERNS); also Alto-Alentejo and Beira-Baixa, which Cintra
+    (1971:726) delimits by exactly this u→[y] isogloss ("palatalização… da
+    vogal tónica u"), and whitepaper5 rule BB1.
+
+    The fronting is blocked before a tautosyllabic coda liquid or sibilant
+    (*azul* [ɐˈzuɫ], *Furnas* [ˈfuɾnɐʃ]), where São Miguel keeps [u] — matching
+    o2i ``ACO_U_KEEP_BEFORE_CODA`` (followed by ``ɫ l ɾ ʁ ʃ ʒ``). ``postag``
+    unused (see module note).
+
+    Source: Cintra (1971:726); o2i ACO_U_KEEP_BEFORE_CODA + ACO_STRESSED_U_FRONTING
+    (Rogers 1948).
     """
-    return phonemes.replace("ˈu", "ˈy")
+    return re.sub(r"ˈu(?![ɫlɾʁʃʒ])", "ˈy", phonemes)
 
 
 def monophthongize_oi(word: str, phonemes: str, postag: str = "NOUN") -> str:

--- a/tugaphone/morpheme_transforms.py
+++ b/tugaphone/morpheme_transforms.py
@@ -27,8 +27,16 @@ def spell_v_as_b(word: str, postag: str = "NOUN") -> str:
     produce [b] directly, which composes correctly with downstream rules that
     reference /b/.
 
-    Distribution: all northern varieties + Galician (Cintra 1971; whitepaper4
-    rule N1). Case is preserved for the leading character.
+    Distribution: all northern varieties + Galician (Cintra 1971:87; whitepaper4
+    rule N1). Case is preserved for the leading character. ``postag`` is
+    accepted for signature uniformity but unused (this is not POS-conditioned).
+
+    CAVEAT: routing through the G2P as ⟨b⟩ forces the STOP outcome [b] in every
+    position, losing the intervocalic spirant realisation [β] that the merged
+    labial has (Cintra 1971:87 "b ou β"; see :func:`ipa_transforms.betacism`,
+    which keeps [β] intervocalically). Acceptable only as a coarse input hack;
+    prefer the post-G2P ``betacism`` transform where the [b]~[β] allophony
+    matters.
     """
     out = re.sub(r"v", "b", word)
     out = re.sub(r"V", "B", out)
@@ -43,8 +51,17 @@ def archaic_ch_to_x(word: str, postag: str = "NOUN") -> str:
     phonemizer's /ʃ/ path so the post-G2P affrication rule can target it
     consistently regardless of lexicon idiosyncrasies.
 
-    Distribution: Transmontano / Alto-Minhoto, archaic (Cintra 1971;
-    whitepaper4 §3). Case-insensitive on the digraph.
+    Distribution: Transmontano / Alto-Minhoto, archaic (Cintra 1971, trait 3;
+    whitepaper4 §3). Case-insensitive on the digraph. ``postag`` unused.
+
+    DO NOT COMPOSE with :func:`ipa_transforms.palatal_affrication_ch`. That
+    post-G2P rule counts ``word.lower().count("ch")`` to decide how many /ʃ/ to
+    affricate; after this respelling the word contains no ⟨ch⟩, so the count is
+    0 and no affrication fires — the two rules cancel. The phenomenon (⟨ch⟩ kept
+    as a distinct historical affricate /tʃ/, Cintra trait 3) is correct, but the
+    correct mechanism is ``palatal_affrication_ch`` ALONE, applied to the
+    original spelling. This respelling merges ⟨ch⟩ into the ⟨x⟩=/ʃ/ path and is
+    retained only for callers that deliberately want the merged /ʃ/ outcome.
     """
     out = re.sub(r"ch", "x", word)
     out = re.sub(r"Ch", "X", out)

--- a/tugaphone/regional.py
+++ b/tugaphone/regional.py
@@ -29,6 +29,7 @@ from tugaphone.ipa_transforms import (
     nasal_diphthongization_e,
     final_nasal_denasalization,
     rising_diphthong_o,
+    rising_diphthong_e,
     initial_z_devoicing,
     intervocalic_s_voicing,
     intervocalic_d_deletion,
@@ -96,19 +97,20 @@ _IPA_REGISTRY: Tuple[GroundedRule, ...] = (
     _ipa(palatal_affrication_ch, "<ch> /ʃ/→[tʃ]", "Transmontano / Alto-Minhoto", "Cintra 1971; wp4 N3; wp5 TM2"),
     _ipa(rhotic_realization, "onset /ʁ/→[r]", "Rural/conservative north + interior", "Cintra 1971; DIALECT_PATTERNS"),
     _ipa(epenthetic_j_before_palatal, "V→Vj / __[ʎɲʃ]", "Minho / northwest", "Cintra 1971; DIALECT_PATTERNS"),
-    _ipa(rising_diphthong_o, "stressed /o/→[uo]", "Porto / Douro Litoral", "Cintra 1971; wp5 PT2; wp4 §3.3"),
-    _ipa(intervocalic_s_voicing, "/s/→[z] / V_V, V_#", "Transmontano", "Cintra 1971; DIALECT_PATTERNS"),
-    _ipa(initial_z_devoicing, "#/z/→[s]", "Transmontano", "Cintra 1971; DIALECT_PATTERNS"),
+    _ipa(rising_diphthong_o, "stressed close /o/→[wo]", "Porto / Baixo-Minho / Douro-Litoral", "Cintra 1971:684; wp5 PT2"),
+    _ipa(rising_diphthong_e, "stressed close /e/→[je]", "Porto / Baixo-Minho / Douro-Litoral", "Cintra 1971:684"),
+    _ipa(intervocalic_s_voicing, "apico-alveolar ⟨s,ss⟩ [s̺]/[z̺] (PLACE)", "Transmontano / Alto-Minhoto", "Cintra 1971:93; Álvarez Pérez 2014"),
+    _ipa(initial_z_devoicing, "#/z/→[s] (GALICIAN trait 6)", "Galician / contact fringe", "Cintra 1971:451-457"),
     _ipa(final_nasal_denasalization, "-agem /ʒẽ/→[ʒe]", "Transmontano", "Cintra 1971; DIALECT_PATTERNS"),
     _ipa(nasal_diphthongization_e, "/ẽ/→[eĩ] / _C", "Fafe / inner Minho", "DIALECT_PATTERNS"),
     _ipa(nasal_glide_palatalization, "Ṽj̃→Ṽɲ / _#", "Braga / northwest", "DIALECT_PATTERNS"),
     _ipa(intervocalic_d_deletion, "intervocalic /d ð/→∅", "Alentejo, Algarve, Beira-Baixa", "Cintra 1971; DIALECT_PATTERNS"),
     _ipa(simplify_nasal_diphthong_em, "-em [ɐ̃j̃]→[ẽ]", "Alentejo / central-south", "Cintra 1971; DIALECT_PATTERNS"),
     _ipa(simplify_meu_class, "meu [ew]→[e]", "Alentejo, Algarve", "Cintra 1971; DIALECT_PATTERNS"),
-    _ipa(sibilant_voicing_sandhi, "final [ʃ]→[ʒ] / _V", "South / insular sandhi", "Cintra 1971; DIALECT_PATTERNS"),
-    _ipa(lateral_palatalization, "/l/→[ʎ] / i_", "Madeira, Açores", "ALEPG (Saramago 2006); DIALECT_PATTERNS"),
-    _ipa(nasal_diphthong_to_nasal_plus_n, "Ṽj̃ʃ→Ṽns / _#", "Madeira, Açores", "ALEPG; DIALECT_PATTERNS"),
-    _ipa(fronted_stressed_u, "stressed /u/→[y]", "Açores (São Miguel)", "ALEPG; DIALECT_PATTERNS; wp5 BB1"),
+    _ipa(sibilant_voicing_sandhi, "coda [ʃ]→[ʒ] / _ #V (external sandhi)", "South / insular sandhi", "Mateus & d'Andrade 2000; PWL"),
+    _ipa(lateral_palatalization, "/l/→[ʎ] / i_V", "Madeira, Açores", "Segura 2013; o2i MAD_L_PALATALISATION"),
+    _ipa(nasal_diphthong_to_nasal_plus_n, "Ṽj̃ʃ→Ṽns / _#", "Madeira, Açores", "ALEPG; o2i madeira/acores"),
+    _ipa(fronted_stressed_u, "stressed /u/→[y] (not /_coda liq/sib)", "Açores (São Miguel), Alto-Alentejo, Beira-Baixa", "Cintra 1971:726; o2i ACO_U_*; wp5 BB1"),
     _ipa(monophthongize_oi, "[oj]→[o]", "Açores", "DIALECT_PATTERNS"),
 )
 
@@ -271,13 +273,18 @@ Source: Cintra (1971), the betacism and diphthong-retention isoglosses.
 PortoDialect = RegionalTransforms(
     ipa_rules=[
         rising_diphthong_o,
+        rising_diphthong_e,
         *_NORTHERN_CORE,
     ]
 )
-"""Porto / Douro Litoral: northern core + rising diphthong stressed /o/→[uo].
+"""Porto / Baixo-Minho / Douro-Litoral: northern core + tonic-close-vowel
+diphthongisation ([e]→[je], [o]→[wo]).
 
-Features: rising_diphthong_o, retain_ou_diphthong, retain_ei_diphthong, betacism.
-Source: Cintra (1971); whitepaper5 PT2 (Porto e/o diphthongisation).
+Features: rising_diphthong_o, rising_diphthong_e, retain_ou_diphthong,
+retain_ei_diphthong, betacism.
+Cintra's (1971:684) single defining Porto marker is the diphthongisation of
+BOTH close tonic vowels ("[e] em [je], [o] em [wo]"), so both halves compose.
+Source: Cintra (1971:684); whitepaper5 PT2.
 """
 
 # Maximal Minhoto reading: the northern core plus the conservative/rural
@@ -339,18 +346,22 @@ Source: DIALECT_PATTERNS field notes ("a geinte só sabe verdadeirameinte…").
 TrasMontanoDialect = RegionalTransforms(
     ipa_rules=[
         palatal_affrication_ch,
-        initial_z_devoicing,
         intervocalic_s_voicing,
         final_nasal_denasalization,
         conservative_o_nasal_retention,
         *MinhoDialect.ipa_rules,
     ]
 )
-"""Transmontano (northeast): <ch> affrication + sibilant reorganisation + Minho.
+"""Transmontano (northeast): <ch> affricate [tʃ] + apico-alveolar four-sibilant
+system + Minho.
 
-Features: palatal_affrication_ch, initial_z_devoicing, intervocalic_s_voicing,
+Features: palatal_affrication_ch, intervocalic_s_voicing (apico-alveolar PLACE),
 final_nasal_denasalization, conservative_o_nasal_retention + Minho set.
-Source: Cintra (1971); whitepaper4 §3.2; DIALECT_PATTERNS.
+``initial_z_devoicing`` is deliberately NOT composed here: word-initial /z/→[s]
+is Cintra's GALICIAN trait 6 (1971:451-457), and conservative Transmontano
+instead KEEPS the voiced apico-alveolar [z̺]. Cintra's apico-alveolar sibilant
+(trait 2) is his single most diagnostic North/South isogloss.
+Source: Cintra (1971:93, trait 2; 429-431, trait 3); Álvarez Pérez (2014).
 """
 
 CoimbraDialect = RegionalTransforms(
@@ -370,14 +381,18 @@ AlentejoDialect = RegionalTransforms(
         simplify_meu_class,
         simplify_nasal_diphthong_em,
         monophthongize_ei,
+        fronted_stressed_u,
         sibilant_voicing_sandhi,
     ]
 )
-"""Alentejo: intervocalic /d/ deletion, meu→[me], -em→[ẽ], ei→[e].
+"""Alentejo: intervocalic /d/ deletion, meu→[me], -em→[ẽ], ei→[e], u→[y].
 
 Features: intervocalic_d_deletion, simplify_meu_class,
-simplify_nasal_diphthong_em, monophthongize_ei, sibilant_voicing_sandhi.
-Source: Cintra (1971); DIALECT_PATTERNS.
+simplify_nasal_diphthong_em, monophthongize_ei, fronted_stressed_u,
+sibilant_voicing_sandhi.
+Cintra (1971:726) delimits Alto-Alentejo by exactly the tonic u→[y] isogloss
+(shared with Beira-Baixa), so the fronting (coda-blocked) is composed here.
+Source: Cintra (1971:726); DIALECT_PATTERNS.
 """
 
 AlgarveDialect = RegionalTransforms(


### PR DESCRIPTION
Research-backed corrections to the phonological CONTENT of the 27 accent primitives (`ipa_transforms.py` + `morpheme_transforms.py`), driven by the transform-validation report. The compositional framework, every primitive function, and all public call signatures are kept — this corrects content, it does not delete primitives.

Each change cites Cintra (1971), the o2i pt-PT specs, or native transcripts, in the corrected docstring.

## Wrong -> corrected
- **rising_diphthong_o**: `[uo]` -> `[wo]` (Cintra 1971:684 "[o] em [wo]"). Added companion **rising_diphthong_e** (`[e]` -> `[je]`, same passage) — Porto's defining marker diphthongises BOTH close tonic vowels. Porto preset now composes both; o2i `PT_PORTO_DIPHTHONGISE_E/_O`.
- **intervocalic_s_voicing**: re-scoped from "voice ç to [z]" (unsourced) to Cintra's apico-alveolar PLACE contrast (1971:93, his most diagnostic isogloss). `moço` stays `[ˈmosu]`; `passo` -> `[ˈpas̺u]`, `casa` -> `[ˈkaz̺ɐ]`; laminal ⟨c,ç,z⟩ untouched. Conservative, orthographically-gated subset (the full four-sibilant model is o2i's trasosmontes spec).
- **initial_z_devoicing**: re-attributed to the GALICIAN trait 6 (Cintra 1971:451-457), not Transmontano. Removed from the Transmontano preset (the NE keeps voiced apical `[z̺]`); kept as a Galician-contact reading.
- **sibilant_voicing_sandhi**: made true EXTERNAL sandhi — coda `[ʃ]` voices only across a word boundary before a vowel-initial word. Isolated tokens no longer voiced word-internally (`meus` said alone stays `[meʃ]`).
- **archaic_ch_to_x** (morpheme): documented that it must NOT compose with `palatal_affrication_ch` (its `count("ch")` reads 0 after respelling); the correct mechanism is the post-G2P affrication alone.

## Refined
- **betacism**: keep `[b]~[β]` (Cintra 1971:87 "b ou β"); intervocalic /v/ -> `[β]`, existing `[β]` preserved; deleted the false "β conflicts with Cintra" comment.
- **fronted_stressed_u**: block before a coda liquid/sibilant (`azul` -> `[ɐˈzuɫ]`, o2i `ACO_U_KEEP_BEFORE_CODA`); exposed in the Alentejo preset (Cintra 1971:726 delimits Alto-Alentejo by this isogloss).
- **lateral_palatalization**: dropped the word-final branch, require a following vowel (o2i `MAD_L_PALATALISATION`); coda dark `[ɫ]` never palatalised (`mil` unchanged).
- **spell_v_as_b** (morpheme): documented that it forces the stop outcome and loses the `[β]` realisation.

## Kept correct (unchanged)
retain_ou_diphthong, retain_ei_diphthong, monophthongize_ei, palatal_affrication_ch, nasal_diphthong_to_nasal_plus_n.

## Flagged UNVERIFIED (behaviour unchanged, caution note added)
nasal_vowel_raising, epenthetic_j_before_palatal, final_nasal_denasalization, nasal_diphthongization_e, nasal_glide_palatalization, open_vowel_preference (and partial notes on reduce_vowel_centralization, conservative_o_nasal_retention). These rest only on the repo's own DIALECT_PATTERNS field notes; not trust-fixed.

## postag
Documented as unused across all primitives (no body reads it). Genuine POS homographs are the separate `dialects.py` IRREGULAR table, not touched here.

## Tests
Updated the tests that pinned the old (wrong) behaviour to the corrected cited forms, each with a source comment; added failing-first tests for the corrections (apical place, cross-word sandhi, coda-blocked u-fronting, coda-l, rising_diphthong_e, intervocalic [β]). Full suite: 278 passed, 4 skipped (was 272 passed) — the delta is the 6 new correction tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)