### PR TITLE
feat: require bifonia and always run its homograph disambiguation

### DIFF
--- a/docs/homographs.md
+++ b/docs/homographs.md
@@ -14,9 +14,9 @@ tugaphone handles both in a single pipeline.
 
 ## Meaning-based: bifonia
 
-When [bifonia](https://github.com/TigreGotico/bifonia) is installed (it is a
-required dependency), `TugaPhonemizer.phonemize_sentence` calls
-`bifonia.add_extra_diacritics` on the input text before tagging. bifonia
+[bifonia](https://github.com/TigreGotico/bifonia) is a required dependency, so
+`TugaPhonemizer.phonemize_sentence` always calls
+`bifonia.add_extra_diacritics` on Portuguese input before tagging. bifonia
 performs context-sensitive sense disambiguation and inserts the open/closed
 vowel diacritic directly into the orthography, so the grapheme rules that
 follow produce the correct vowel quality without any special casing.
@@ -35,8 +35,9 @@ print(ph.phonemize_sentence("A sede da empresa fica em Lisboa."))
 # ˈɐ ˈsɛ·dɨ ˈdɐ ẽ·pɾˈe·zɐ ˈfi·kɐ ˈẽ liʒ·bˈo·ɐ ˈ···
 ```
 
-If bifonia is not importable, the pipeline continues without it and falls back
-to the POS-based table.
+The POS-based table below handles the remaining homographs whose readings
+differ in part of speech; bifonia adds the same-part-of-speech pairs (the
+`sede` thirst/seat case) that a POS tagger cannot split.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "silabificador",
     "tugatagger[brill]",
     "tugalex",
-    "bifonia",
+    "bifonia>=0.1.1",
     "orthography2ipa>=1.71.0a1",
 ]
 

--- a/tests/test_bifonia_homographs.py
+++ b/tests/test_bifonia_homographs.py
@@ -5,14 +5,9 @@ the open/closed-vowel diacritic the phonemizer reads, so the same spelling maps 
 the correct vowel from context — something a part-of-speech table cannot do when
 both readings share a part of speech (sede thirst/seat are both nouns).
 """
-import importlib.util
-
 import pytest
 
 from tugaphone import TugaPhonemizer
-
-_HAS_BIFONIA = importlib.util.find_spec("bifonia") is not None
-pytestmark = pytest.mark.skipif(not _HAS_BIFONIA, reason="bifonia not installed")
 
 
 @pytest.fixture(scope="module")
@@ -44,3 +39,17 @@ def test_para_preposition_vs_verb(ph):
     assert "pɐɾɐ" in prep         # reduced a — preposition
     assert "pɐɾɐ" not in verb     # not the reduced preposition form
     assert "pa" in verb           # stressed a — verb (stops)
+
+
+def test_acordo_noun_is_closed_verb_is_open(ph):
+    noun = _clean(ph.phonemize_sentence("O acordo de paz foi assinado."))
+    verb = _clean(ph.phonemize_sentence("Eu acordo cedo todos os dias."))
+    assert "koɾ" in noun         # closed o — agreement (noun)
+    assert "kɔɾ" in verb         # open ɔ — I wake (verb)
+
+
+def test_gosto_noun_is_closed_verb_is_open(ph):
+    verb = _clean(ph.phonemize_sentence("Gosto muito de ti."))
+    noun = _clean(ph.phonemize_sentence("O gosto é amargo."))
+    assert "ɡɔʃ" in verb         # open ɔ — I like (verb)
+    assert "ɡoʃ" in noun         # closed o — taste (noun)

--- a/tugaphone/__init__.py
+++ b/tugaphone/__init__.py
@@ -12,14 +12,11 @@ from tugaphone.registry import (DialectEntry, resolve_dialect, list_dialects,
 from tugaphone.registry import get_dialect_inventory as _registry_inventory
 from tugaphone.tokenizer import Sentence, DialectInventory
 
-try:
-    # Disambiguates heterophonic homographs (sede = thirst vs seat, forma = mould
-    # vs shape, …) by meaning and marks the result with the open/closed-vowel
-    # diacritic the phonemizer reads directly. Optional: phonemization still runs
-    # without it, falling back to the part-of-speech homograph table.
-    from bifonia import add_extra_diacritics as _bifonia_diacritics
-except ImportError:
-    _bifonia_diacritics = None
+# Disambiguates heterophonic homographs (sede = thirst vs seat, forma = mould
+# vs shape, …) by meaning and marks the result with the open/closed-vowel
+# diacritic the grapheme rules read directly — resolving same-part-of-speech
+# pairs the tagger cannot split.
+from bifonia import add_extra_diacritics as _bifonia_diacritics
 
 
 class TugaPhonemizer:
@@ -70,7 +67,7 @@ class TugaPhonemizer:
         Returns:
             phonemized (str): Space-separated phoneme tokens for each word; punctuation tokens are preserved unchanged.
         """
-        if _bifonia_diacritics is not None and lang.startswith("pt"):
+        if lang.startswith("pt"):
             # Resolve heterophone meaning first; the inserted diacritics drive the
             # correct vowel quality in the grapheme rules below.
             sentence = _bifonia_diacritics(sentence)


### PR DESCRIPTION
## What

Hardens the already-declared **bifonia** dependency into a guaranteed part of the pt phonemization path, and covers it in the always-run test suite.

`bifonia` is listed in `dependencies`, yet the integration treated it as optional in two places that let it silently no-op:
- `tugaphone/__init__.py` imported it under `try/except ImportError`, falling back to `_bifonia_diacritics = None`.
- `tests/test_bifonia_homographs.py` guarded the whole module with `pytest.mark.skipif(not _HAS_BIFONIA)`.

For a correct install neither path ever triggers, so they were dead defensive code that also violates the org rule *never skip tests on a missing declared dependency*.

## Changes

- **Direct import** of `bifonia.add_extra_diacritics` (drop `try/except`); simplify the call guard to `lang.startswith("pt")`.
- **Floor-pin** `bifonia>=0.1.1` in `pyproject.toml`.
- **Drop the `skipif`** so the homograph path always runs.
- **Add same-POS heterophone tests** (`acordo` noun/verb, `gosto` noun/verb) — the exact case a POS tagger cannot split, which is bifonia's whole reason to exist.

## How it works

bifonia resolves the intended *sense* from context and re-marks the word with a non-canonical open/closed diacritic (ó/é vs ô/ê); tugaphone's existing grapheme rules then read that diacritic and emit the correct vowel quality. Verified live:

| word | sense | IPA |
|---|---|---|
| acordo | agreement (noun) | ɐˈ**ko**ɾdu |
| acordo | I wake (verb) | ɐˈ**kɔ**ɾdu |
| sede | thirst | ˈ**se**dɨ |
| sede | seat/HQ | ˈ**sɛ**dɨ |
| gosto | I like (verb) | ˈɡ**ɔ**ʃtu |
| gosto | taste (noun) | ˈɡ**o**ʃtu |

## Test

`uv pip install -e .[test]` then `pytest tests/` → **277 passed, 1 skipped** (fresh venv; bifonia 0.1.1 resolves from PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Portuguese pronunciation for homographs, including cases such as *acordo*, *gosto*, and *sede*.
  * Added more accurate vowel distinctions based on word meaning and grammatical role.

* **Bug Fixes**
  * Portuguese sentence phonemization now consistently applies homograph disambiguation, improving pronunciation accuracy.

* **Documentation**
  * Updated homograph documentation to reflect the current pronunciation behavior and supported cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->